### PR TITLE
0310 - 修正兩種 log 頁面顯示機制

### DIFF
--- a/src/app/field-management/field-management.component.scss
+++ b/src/app/field-management/field-management.component.scss
@@ -91,7 +91,7 @@ mat-stepper {
   text-align: center;
 }
 
-// 進度調居中並設定大小 @12/28 Add
+// Spinner 居中並設定大小 @12/28 Add
 .progress-spinner-container {
   display: flex;
   justify-content: center;

--- a/src/app/field-management/field-management.component.ts
+++ b/src/app/field-management/field-management.component.ts
@@ -30,7 +30,7 @@ import { localBSList } from '../shared/local-files/BS/For_queryBsList';         
 import { localFieldSnapshotList } from '../shared/local-files/Field/For_queryFieldSnapshotList';  // @2024/03/06 Add
 
 // For download snapshot 
-import * as XLSX from 'xlsx';         // @2024/03/09 Add 
+import * as XLSX from 'xlsx';           // @2024/03/09 Add 
 //import { saveAs } from 'file-saver';  // @2024/03/09 Add 
 
 @Component({

--- a/src/app/log-management/log-management.component.html
+++ b/src/app/log-management/log-management.component.html
@@ -101,7 +101,7 @@
       </thead>
       <tbody>
         <tr *ngFor="let opt of userLogsToDisplay | paginate: { itemsPerPage: pageSize,
-           currentPage: p, totalItems: userLogsToDisplay.length, id: 'userlogsList' }; let i = index">
+           currentPage: p, totalItems: UserLogsList.logNumber, id: 'userlogsList' }; let i = index">
           <td>{{ (p - 1) * pageSize + i + 1 }}</td> <!-- 更動為動態生成每條 User log 的編號 @11/14 changed by yuchen-->
           <td>{{ opt.userid }}</td>
           <td>{{ opt.logtype }}</td>
@@ -224,7 +224,7 @@
       </thead>
       <tbody>
         <tr *ngFor="let opt of neLogsToDisplay | paginate: { itemsPerPage: pageSize,
-           currentPage: p, totalItems: neLogsToDisplay.length, id: 'nelogsList' }; let i = index">
+           currentPage: p, totalItems: NELogsList.logNumber, id: 'nelogsList' }; let i = index">
           <td>{{ (p - 1) * pageSize + i + 1 }}</td> <!-- 更動為動態生成每條 NE log 的編號 @11/14 changed by yuchen-->
           <td>{{opt.userid}}</td>
           <td>{{opt.comp_name}}</td>

--- a/src/app/log-management/log-management.component.html
+++ b/src/app/log-management/log-management.component.html
@@ -100,21 +100,37 @@
         </tr>
       </thead>
       <tbody>
-        <tr *ngFor="let opt of userLogsToDisplay | paginate: { itemsPerPage: pageSize,
-           currentPage: p, totalItems: UserLogsList.logNumber, id: 'userlogsList' }; let i = index">
-          <td>{{ (p - 1) * pageSize + i + 1 }}</td> <!-- 更動為動態生成每條 User log 的編號 @11/14 changed by yuchen-->
-          <td>{{ opt.userid }}</td>
-          <td>{{ opt.logtype }}</td>
-          <td class="center">{{ opt.loglevel }}</td>
-          <td class="logmsg">{{ opt.logmsg }}</td>
-          <td>{{ opt.logtime }}</td>
-          <td><mat-icon tooltip="{{ languageService.i18n['view_detail'] }}" (click)="openUserlogDetail(opt)">remove_red_eye</mat-icon></td>
-        </tr>        
-        <tr class="notFind" *ngIf="userLogsToDisplay.length === 0">
-          <td colspan="7">{{languageService.i18n['no_results']}}</td>
-        </tr> 
+
+        <!-- 當數據正在加載時顯示進度條 @2024/03/10 Add -->
+        <ng-container *ngIf="isGetUserLogsInfoLoading">
+          <tr>
+            <td colspan="6">
+              <div class="progress-spinner-container">
+                <!-- 指示器大小設置 -->
+                <mat-progress-spinner class="custom-spinner-color" mode="indeterminate" [diameter]="90"></mat-progress-spinner>
+              </div>
+            </td>
+          </tr>
+        </ng-container>
+
+        <!-- 加載完成後顯示 User Logs 的數據 @2024/03/10 Add -->
+        <ng-container *ngIf="!isGetUserLogsInfoLoading">
+          <tr *ngFor="let opt of userLogsToDisplay | paginate: { itemsPerPage: pageSize,
+            currentPage: p, totalItems: UserLogsList.logNumber, id: 'userlogsList' }; let i = index">
+            <td>{{ (p - 1) * pageSize + i + 1 }}</td> <!-- 更動為動態生成每條 User log 的編號 @11/14 changed by yuchen-->
+            <td>{{ opt.userid }}</td>
+            <td>{{ opt.logtype }}</td>
+            <td class="center">{{ opt.loglevel }}</td>
+            <td class="logmsg">{{ opt.logmsg }}</td>
+            <td>{{ opt.logtime }}</td>
+            <td><mat-icon tooltip="{{ languageService.i18n['view_detail'] }}" (click)="openUserlogDetail(opt)">remove_red_eye</mat-icon></td>
+          </tr>        
+          <tr class="notFind" *ngIf="userLogsToDisplay.length === 0">
+            <td colspan="7">{{languageService.i18n['no_results']}}</td>
+          </tr>
+        </ng-container>
       </tbody>
-      </table>
+    </table>
       <!-- pagination @11/01 Add by yuchen --> 
       <!-- <span class="total">{{languageService.i18n['UserLog.total1']}} {{userLogsToDisplay.length}} {{languageService.i18n['UserLog.total2']}}</span> -->
       <!-- 使用 getTotalLogsText 函數來決定顯示 'User Log' 還是 'User Logs' @11/21 Add by yuchen -->
@@ -223,24 +239,40 @@
         </tr>
       </thead>
       <tbody>
-        <tr *ngFor="let opt of neLogsToDisplay | paginate: { itemsPerPage: pageSize,
-           currentPage: p, totalItems: NELogsList.logNumber, id: 'nelogsList' }; let i = index">
-          <td>{{ (p - 1) * pageSize + i + 1 }}</td> <!-- 更動為動態生成每條 NE log 的編號 @11/14 changed by yuchen-->
-          <td>{{opt.userid}}</td>
-          <td>{{opt.comp_name}}</td>
-          <td>{{opt.operation}}</td>
-          <td class="truncate">
-            {{ opt.req_data | truncate:118 }}
-          </td>
-          <td>
-            {{ opt.resp_data | truncate:118 }}
-          </td>          
-          <td>{{opt.logtime}}</td>
-          <td><mat-icon tooltip="{{languageService.i18n['view_detail']}}" (click)="openNElogDetail(opt)">remove_red_eye</mat-icon></td>
-        </tr>
-        <tr class="notFind" *ngIf="NELogsList.logNumber === 0">
-          <td colspan="7">{{languageService.i18n['no_results']}}</td>
-        </tr> 
+
+        <!-- 當數據正在加載時顯示進度條 @2024/03/10 Add -->
+        <ng-container *ngIf="isGetNELogsInfoLoading">
+          <tr>
+            <td colspan="6">
+              <div class="progress-spinner-container">
+                <!-- 指示器大小設置 -->
+                <mat-progress-spinner class="custom-spinner-color" mode="indeterminate" [diameter]="90"></mat-progress-spinner>
+              </div>
+            </td>
+          </tr>
+        </ng-container>
+
+        <!-- 加載完成後顯示 NE Logs 的數據 @2024/03/10 Add -->
+        <ng-container *ngIf="!isGetNELogsInfoLoading">
+          <tr *ngFor="let opt of neLogsToDisplay | paginate: { itemsPerPage: pageSize,
+              currentPage: p, totalItems: NELogsList.logNumber, id: 'nelogsList' }; let i = index">
+            <td>{{ (p - 1) * pageSize + i + 1 }}</td> <!-- 更動為動態生成每條 NE log 的編號 @11/14 changed by yuchen-->
+            <td>{{opt.userid}}</td>
+            <td>{{opt.comp_name}}</td>
+            <td>{{opt.operation}}</td>
+            <td class="truncate">
+              {{ opt.req_data | truncate:118 }}
+            </td>
+            <td>
+              {{ opt.resp_data | truncate:118 }}
+            </td>          
+            <td>{{opt.logtime}}</td>
+            <td><mat-icon tooltip="{{languageService.i18n['view_detail']}}" (click)="openNElogDetail(opt)">remove_red_eye</mat-icon></td>
+          </tr>
+          <tr class="notFind" *ngIf="NELogsList.logNumber === 0">
+            <td colspan="7">{{languageService.i18n['no_results']}}</td>
+          </tr> 
+        </ng-container>
       </tbody>
     </table>
     

--- a/src/app/log-management/log-management.component.scss
+++ b/src/app/log-management/log-management.component.scss
@@ -100,6 +100,23 @@ table.neLog tr td:nth-last-child(4) {
 table tbody td.time {
   text-align: left;
 }
+
+// @2024/03/10 Add
+// Spinner 居中並設定大小
+.progress-spinner-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 90px; 
+}
+
+// @2024/03/10 Add
+// 設定進度調 (Spinner) 的顏色
+::ng-deep .mat-progress-spinner circle {
+  stroke: #7cbaec !important;
+}
+
+
 .filter {
   position: relative;
   padding-left: 15em;

--- a/src/app/log-management/log-management.component.ts
+++ b/src/app/log-management/log-management.component.ts
@@ -262,7 +262,7 @@ export class LogManagementComponent implements OnInit, OnDestroy {
         // 取消之前的 API 訂閱
         if ( this.queryLogList ) this.queryLogList.unsubscribe();
 
-        // 改切割至不傳入時分秒 @2024/03/10 Add
+        // 改只保留傳入日期的部分 @2024/03/10 Add
         const formattedDate = this.commonService.dealPostDate(this.searchForm.controls['from'].value);
         const start = formattedDate.split(' ')[0]; // 獲取日期部分,例如 '2024-03-10'
         
@@ -365,7 +365,7 @@ export class LogManagementComponent implements OnInit, OnDestroy {
       // 取消之前的任何 API 訂閱
       if ( this.queryUserNetconfLog ) this.queryUserNetconfLog.unsubscribe();
 
-      // 改切割至不傳入時分秒 @2024/03/10 Add
+      // 改只保留傳入日期的部分 @2024/03/10 Add
       const formattedDate = this.commonService.dealPostDate(this.searchForm.controls['from'].value);
       const start = formattedDate.split(' ')[0]; // 獲取日期部分,例如 '2024-03-10'
       

--- a/src/app/log-management/log-management.component.ts
+++ b/src/app/log-management/log-management.component.ts
@@ -273,8 +273,8 @@ export class LogManagementComponent implements OnInit, OnDestroy {
         // 從 searchForm 中獲取篩選條件
         const params = {
           userid: this.searchForm.get('UserID')?.value || '',     // 取得 userid，如不存在設為空字串
-          start, // 取得開始日期
-          end,   // 取得結束日期
+          start, // 取得開始日期 - 目前後端無法篩選時分秒
+          end,   // 取得結束日期 - 目前後端無法篩選時分秒
           //logType: this.searchForm.get('UserLogType')?.value,    // 取得 User Log 類型
           //keyword: this.searchForm.get('keyword')?.value || '',  // 取得想搜尋的關鍵字
           offset: (this.p - 1) * this.pageSize,                    // 計算分頁的 offset
@@ -377,8 +377,8 @@ export class LogManagementComponent implements OnInit, OnDestroy {
       const params = {
         userid: this.searchForm.get('UserID')?.value || '',     // 取得 userid，如不存在設為空字串
         nEname: this.searchForm.get('neName')?.value || '',     // 取得 nEname，如不存在設為空字串
-        start, // 取得開始日期
-        end,   // 取得結束日期
+        start, // 取得開始日期 - 目前後端無法篩選時分秒
+        end,   // 取得結束日期 - 目前後端無法篩選時分秒
         neLogType: this.searchForm.get('NELogType')?.value,     // 取得 NE Log 類型
         keyword: this.searchForm.get('keyword')?.value || '',   // 取得想搜尋的關鍵字
         offset: (this.p - 1) * this.pageSize,                   // 計算分頁的 offset，以便從正確的記錄開始獲取 Log

--- a/src/app/log-management/log-management.component.ts
+++ b/src/app/log-management/log-management.component.ts
@@ -292,7 +292,7 @@ export class LogManagementComponent implements OnInit, OnDestroy {
             this.totalItems = this.UserLogsList.logNumber;
             console.log( 'UserLogs Num:', this.UserLogsList.logNumber );
             console.log( 'totalItems:', this.totalItems );
-            this.UserloginfoDeal();   // 調用處理 User Log 訊息的函數
+            //this.UserloginfoDeal();   // 調用處理 User Log 訊息的函數
 
             // 只有在第一頁時才執行搜尋 @12/06 Add
             if (this.p === 1) {   
@@ -395,7 +395,7 @@ export class LogManagementComponent implements OnInit, OnDestroy {
           this.totalItems = this.NELogsList.logNumber;
           console.log( 'NELogs Num:', this.NELogsList.logNumber );
           console.log( 'totalItems:', this.totalItems );
-          this.NEloginfoDeal();       // 調用處理 NE Log 訊息的函數
+          //this.NEloginfoDeal();       // 調用處理 NE Log 訊息的函數
 
           // 只有在第一頁時才執行搜尋 @12/06 Add
           if ( this.p === 1 ) {   

--- a/src/app/log-management/log-management.component.ts
+++ b/src/app/log-management/log-management.component.ts
@@ -231,16 +231,19 @@ export class LogManagementComponent implements OnInit, OnDestroy {
   
   
   // Get User Logs @2024/03/10 Update
-  UserLogs_getNum = 0; // 用於記錄取得 User Logs 資訊之次數
+  UserLogs_getNum = 0;              // 用於記錄取得 User Logs 資訊之次數
+  isGetUserLogsInfoLoading = false; // 用於表示加載 User Logs 的 flag，初始設置為 false @2024/03/10 Add for Progress Spinner
   getUserLogsInfo() {
-    console.log('getUserLogsInfo() - Start');
+    console.log( 'getUserLogsInfo() - Start' );
 
     this.UserLogs_getNum++;
-    console.log('UserLogs_getNum:', this.UserLogs_getNum);
+    console.log( 'UserLogs_getNum:', this.UserLogs_getNum );
 
-    clearTimeout(this.refreshTimeout);
+    clearTimeout( this.refreshTimeout );
 
-    if (this.commonService.isLocal) {
+    this.isGetUserLogsInfoLoading = true; // 設置加載旗標為 true，表示開始加載
+
+    if ( this.commonService.isLocal ) {
 
       // Local Test
       this.UserLogsList = this.commonService.UserLogsList;
@@ -250,10 +253,14 @@ export class LogManagementComponent implements OnInit, OnDestroy {
       if (this.p === 1) {   
         this.search_UserLogs(); 
       }
+
+      // 設置加載旗標為 false，表示加載完成
+      this.isGetUserLogsInfoLoading = false;
+
     } else {
 
         // 取消之前的 API 訂閱
-        if (this.queryLogList) this.queryLogList.unsubscribe();
+        if ( this.queryLogList ) this.queryLogList.unsubscribe();
 
         // 改切割至不傳入時分秒 @2024/03/10 Add
         const formattedDate = this.commonService.dealPostDate(this.searchForm.controls['from'].value);
@@ -291,9 +298,15 @@ export class LogManagementComponent implements OnInit, OnDestroy {
             if (this.p === 1) {   
               this.search_UserLogs(); 
             }
+
+            // 設置加載旗標為 false，表示加載完成
+            this.isGetUserLogsInfoLoading = false;
           },
           error: (error) => {  // 錯誤的 callback
             console.error('Error fetching user logs:', error); // 顯示錯誤訊息
+
+            // 設置加載旗標為 false，表示加載出錯
+            this.isGetUserLogsInfoLoading = false;
           },
           complete: () => {    // 完成的 callback
             console.log('User logs fetch completed');   // 顯示完成訊息
@@ -321,14 +334,17 @@ export class LogManagementComponent implements OnInit, OnDestroy {
   
   // Get NE Logs @2024/03/10 Update
   NELogs_getNum = 0; // 用於記錄取得 NE Logs 資訊之次數
+  isGetNELogsInfoLoading = false; // 用於表示加載 NE Logs 的 flag，初始設置為 false @2024/03/10 Add for Progress Spinner
   getNELogsInfo() {
-    console.log('getNELogsInfo() - Start');
+    console.log( 'getNELogsInfo() - Start' );
     
     this.NELogs_getNum++;
-    console.log('NELogs_getNum:', this.NELogs_getNum);
+    console.log( 'NELogs_getNum:', this.NELogs_getNum );
 
     // 清除之前設置的定時器以避免重複執行
     clearTimeout( this.refreshTimeout );
+
+    this.isGetNELogsInfoLoading = true; // 設置加載旗標為 true，表示開始加載
 
     if ( this.commonService.isLocal ) {
 
@@ -341,10 +357,13 @@ export class LogManagementComponent implements OnInit, OnDestroy {
         this.search_NELogs(); 
       }
 
+      // 設置加載旗標為 false，表示加載完成
+      this.isGetNELogsInfoLoading = false;
+
     } else {
 
       // 取消之前的任何 API 訂閱
-      if (this.queryUserNetconfLog) this.queryUserNetconfLog.unsubscribe();
+      if ( this.queryUserNetconfLog ) this.queryUserNetconfLog.unsubscribe();
 
       // 改切割至不傳入時分秒 @2024/03/10 Add
       const formattedDate = this.commonService.dealPostDate(this.searchForm.controls['from'].value);
@@ -382,9 +401,15 @@ export class LogManagementComponent implements OnInit, OnDestroy {
           if ( this.p === 1 ) {   
             this.search_NELogs(); 
           }
+
+          // 設置加載旗標為 false，表示加載完成
+          this.isGetNELogsInfoLoading = false;
         },
         error: ( error ) => {   // 錯誤的 callback
           console.error( 'Error fetching NE logs:', error ); // 顯示錯誤訊息
+
+          // 設置加載旗標為 false，表示加載出錯
+          this.isGetNELogsInfoLoading = false;
         },
         complete: () => {     // 完成的 callback
           console.log( 'NE logs fetch completed' );          // 顯示完成訊息


### PR DESCRIPTION
1. 修正傳值給 API 的日期格式
2. 將切換頁面函數刷新 Log 數據時機改為只要切換頁數都會刷新(跟舊版相同)
3. 調整統計 log 數量函數，都改直接取後端回傳的 logNumber 值。
4. 將兩種 log 用的 html 分頁控件，計算數據總數的取值(totalItems: )，同樣都改以直接取後端回傳的 logNumber 。