### PR TITLE
Log Mgmt - 調整 log 數據顯示於表格上的機制

### DIFF
--- a/src/app/log-management/log-management.component.html
+++ b/src/app/log-management/log-management.component.html
@@ -53,7 +53,7 @@
 
         <!-- Button of Export User logs to XLSX @11/23 Add by yuchen -->
         <!-- <span tooltip="{{languageService.i18n['UserLog.ExportXLSX']}}" class="material-icons" (click)="exportToExcel('UserLogs')">assignment_returned</span> -->
-        <span tooltip="{{languageService.i18n['UserLog.ExportXLSX']}}" class="material-icons" (click)="exportToExcel('UserLogs')">
+        <span tooltip="{{languageService.i18n['UserLog.Export']}}" class="material-icons" (click)="exportLogsToFile('UserLogs')">
           <mat-icon svgIcon="export_to_xlsx"></mat-icon>
         </span>
         
@@ -66,8 +66,9 @@
       </div>
 
       
-      <!-- Search Criteria Summary of User Logs @12/04 Update by yuchen - added &nbsp;(non-breaking space HTML entity) -->
-      <div *ngIf="isSearch_userLogs" class="filterBY">
+      <!-- Search Criteria Summary of User Logs @2024/03/13 Update -->
+      <!-- <div *ngIf="isSearch_userLogs" class="filterBY"> -->
+      <div class="filterBY"> <!-- 改成常駐顯示 @2024/03/13 Update -->
         <span class="material-symbols-outlined">info</span>{{ languageService.i18n['search_criteria'] }}&nbsp;
         <span *ngIf="afterSearchForm.controls['UserID'].value">
           <label>{{ languageService.i18n['UserLog.userid'] }}:&nbsp;</label>{{ afterSearchForm.controls['UserID'].value }}
@@ -116,7 +117,7 @@
         <!-- 加載完成後顯示 User Logs 的數據 @2024/03/10 Add -->
         <ng-container *ngIf="!isGetUserLogsInfoLoading">
           <tr *ngFor="let opt of userLogsToDisplay | paginate: { itemsPerPage: pageSize,
-                                    currentPage: p, totalItems: UserLogsList.logNumber, id: 'userlogsList' }; let i = index">
+                                    currentPage: p, totalItems: totalLogs, id: 'userlogsList' }; let i = index">
             <td>{{ (p - 1) * pageSize + i + 1 }}</td> <!-- 更動為動態生成每條 User log 的編號 @11/14 changed by yuchen-->
             <td>{{ opt.userid }}</td>
             <td>{{ opt.logtype }}</td>
@@ -190,7 +191,7 @@
 
         <!-- Button of Export NE logs to XLSX @11/23 add by yuchen -->
         <!-- <span tooltip="{{languageService.i18n['NElog.ExportXLSX']}}" class="material-icons" (click)="exportToExcel('NELogs')">assignment_returned</span> -->
-        <span tooltip="{{languageService.i18n['NElog.ExportXLSX']}}" class="material-icons" (click)="exportToExcel('NELogs')">
+        <span tooltip="{{languageService.i18n['NElog.Export']}}" class="material-icons" (click)="exportLogsToFile('NELogs')">
           <mat-icon svgIcon="export_to_xlsx"></mat-icon>
         </span>
 
@@ -201,8 +202,9 @@
         </span> -->
       </div>
 
-      <!-- Search Criteria Summary of NE Logs @12/04 Add by yuchen  -->
-      <div *ngIf="isSearch_neLogs" class="filterBY">
+      <!-- Search Criteria Summary of NE Logs @2024/03/13 Update -->
+      <!-- <div *ngIf="isSearch_neLogs" class="filterBY"> -->
+      <div class="filterBY"> <!-- 改成常駐顯示 @2024/03/13 Update -->
         <span class="material-symbols-outlined">info</span>{{ languageService.i18n['search_criteria'] }}&nbsp;
         <span *ngIf="afterSearchForm.controls['UserID'].value">
           <label>{{ languageService.i18n['NElog.userid'] }}:&nbsp;</label>{{ afterSearchForm.controls['UserID'].value }}
@@ -255,7 +257,7 @@
         <!-- 加載完成後顯示 NE Logs 的數據 @2024/03/10 Add -->
         <ng-container *ngIf="!isGetNELogsInfoLoading">
           <tr *ngFor="let opt of neLogsToDisplay | paginate: { itemsPerPage: pageSize,
-                                  currentPage: p, totalItems: NELogsList.logNumber, id: 'nelogsList' }; let i = index">
+                                  currentPage: p, totalItems: totalLogs, id: 'nelogsList' }; let i = index">
             <td>{{ (p - 1) * pageSize + i + 1 }}</td> <!-- 更動為動態生成每條 NE log 的編號 @11/14 changed by yuchen-->
             <td>{{opt.userid}}</td>
             <td>{{opt.comp_name}}</td>

--- a/src/app/shared/language-models/en-language.ts
+++ b/src/app/shared/language-models/en-language.ts
@@ -383,6 +383,7 @@ export const Enlanguage = {
   'UserLog.detailclose':'Close',      // @11/03 Add by yuchen
   'UserLog.ExportCSV':'Export User Logs to .csv',    // @11/07 Add by yuchen
   'UserLog.ExportXLSX':'Export User Logs to .xlsx',  // @11/23 Add by yuchen
+  'UserLog.Export':'Export User Logs',               // @2024/03/13 Add by yuchen
 
   'NElog.No':'No.',
   'NElog.userid':'User',
@@ -398,5 +399,6 @@ export const Enlanguage = {
   'NElog.detail':'NE Log Detail',  // @11/03 Add by yuchen
   'NElog.detailclose':'Close',     // @11/03 Add by yuchen
   'NElog.ExportCSV':'Export NE Logs to .csv',   // @11/07 Add by yuchen
-  'NElog.ExportXLSX':'Export NE Logs to .xlsx'  // @11/23 Add by yuchen
+  'NElog.ExportXLSX':'Export NE Logs to .xlsx',  // @11/23 Add by yuchen
+  'NElog.Export':'Export NE Logs'                // @2024/03/13 Add by yuchen
 }

--- a/src/app/shared/language-models/tw-language.ts
+++ b/src/app/shared/language-models/tw-language.ts
@@ -382,6 +382,7 @@ export const TwLanguage = {
   'UserLog.detailclose':'關閉',                 // @11/03 add by yuchen
   'UserLog.ExportCSV':'匯出使用者日誌為 .csv',    // @11/07 add by yuchen
   'UserLog.ExportXLSX':'匯出使用者日誌為 .xlsx',  // @11/23 Add by yuchen
+  'UserLog.Export':'匯出使用者日誌',              // @2024/03/13 Add by yuchen
 
   'NElog.No':'編號',
   'NElog.userid':'使用者',
@@ -398,4 +399,5 @@ export const TwLanguage = {
   'NElog.detailclose':'關閉',                 // @11/03 add by yuchen
   'NElog.ExportCSV':'匯出網元日誌為 .csv',      // @11/07 add by yuchen
   'NElog.ExportXLSX':'匯出網元日誌為 .xlsx',    // @11/23 Add by yuchen
+  'NElog.Export':'匯出網元日誌'                 // @2024/03/13 Add by yuchen
 }


### PR DESCRIPTION
1. Local 處理篩選 local files 的機制調整完成。
2. 兩種模式綁定分頁控件、數據總筆數，與依據是否 search 過選擇顯示特定數據機制調整完成。
3. 調整幾項變數、函數命名至更符合其用途。
4. 將兩種 search 函數處理非 Local 模式下，改為直接呼叫 API 篩選，而不透過 getXXLogsInfo() 兩種函數取得篩選結果。
5. 調整點擊 " 匯出 .xlsx 檔案 icon " 顯示的 tooltip 提示訊息。
6. 調整 getXXLogsInfo() 兩種函數應對當用戶有點擊 search 後，且再點擊分頁時取值的相關機制。

### Log Mgmt - 剩餘未處理
 1. 需針對 NE Logs 篩選網元名稱去進一步處理 ( 目前無法正確篩選 )