### PR TITLE
Schedule Mgmt 主頁 - 新增判定排程類別機制

### DIFF
--- a/src/app/schedule-management/schedule-management.component.html
+++ b/src/app/schedule-management/schedule-management.component.html
@@ -32,7 +32,13 @@
                               id: 'PageDisplay_of_scheduleList'
         };">
         <td>{{ schedule.executedtime }}</td>
-        <td>{{ schedule.tickettype }}</td>
+        <td>
+          <label *ngIf=" schedule.tickettype === '0' ">{{ languageService.i18n['sm.sfUpdate'] }}</label>
+          <label *ngIf=" schedule.tickettype === '1' ">{{ languageService.i18n['sm.caReport'] }}</label>
+          <label *ngIf=" schedule.tickettype === '2' ">{{ languageService.i18n['sm.pmReport'] }}</label>
+          <label *ngIf=" schedule.tickettype === '3' ">{{ languageService.i18n['sm.fmReport'] }}</label>
+          <label *ngIf=" schedule.tickettype === '4' ">{{ languageService.i18n['sm.sfReport'] }}</label>
+        </td>
         <td class="icon">
           <label *ngIf=" schedule.ticketstatus === '0' " class="grayLight"></label>
           <label *ngIf=" schedule.ticketstatus === '1' " class="redLight"></label>

--- a/src/app/shared/language-models/en-language.ts
+++ b/src/app/shared/language-models/en-language.ts
@@ -52,7 +52,7 @@ export const Enlanguage = {
   'close': 'Close',                // @2024/01/22 Add
   
 
-  // Field Management (場域管理) @11/30 Add by yuchen
+  // Field Management ( 場域管理 ) @11/30 Add by yuchen
   'field.list':'Field List',
   'field.name':'Field Name',
   'field.bsNum':'Number of BSs',
@@ -193,6 +193,10 @@ export const Enlanguage = {
   'field.legend_all-in-one_bs':'All-in-one BS',     // @12/28 Add
   'field.legend_dist_bs':'O-RAN BS',                // @12/28 Add
   
+  // BS Management ( 基站管理 )
+  'BS.list':'BS List',
+  'BS.name':'BS Name',
+
 
   // Fault Management
   'fm.start':'StartTime',
@@ -357,9 +361,11 @@ export const Enlanguage = {
   'sm.smDownload':'Download report of this schedule',
   'sm.view_detail':'View this schedule in detail',
   'sm.delItem':'Delete this schedule',
-  'sm.fmReport':'Fault Management Report',
-  'sm.pmReport':'Performance Management Report',
-  'sm.sfUpdate':'Software update',
+  'sm.sfReport':'Software Management Report',    // 4
+  'sm.fmReport':'Fault Management Report',       // 3
+  'sm.pmReport':'Performance Management Report', // 2
+  'sm.caReport':'Config Audit Report',           // 1
+  'sm.sfUpdate':'Software Update',               // 0
 
   // Log Management @10/31 add by yuchen
   'LogLists': 'Log Lists',

--- a/src/app/shared/language-models/tw-language.ts
+++ b/src/app/shared/language-models/tw-language.ts
@@ -178,7 +178,6 @@ export const TwLanguage = {
   'field.close':'關閉', // @2024/02/22 Add
   'field.applyReminder': '提醒', // @2024/02/22 Add
   
-  
   'field.report':'場域報表',                        // @12/12 Add
   'field.reportPM':'場域效能 (PM)',                 // @12/12 Add
   'field.reportFM':'告警資訊 (FM)',                 // @12/12 Add
@@ -191,6 +190,10 @@ export const TwLanguage = {
   'field.bsAlarm':'告警',                          // @12/13 Add
   'field.legend_all-in-one_bs':'一體式基站',        // @12/28 Add
   'field.legend_dist_bs':'O-RAN基站',              // @12/28 Add
+
+  // BS Management ( 基站管理 )
+  'BS.list':'基站列表',
+  'BS.name':'基站名稱',
 
   // Fault Management (故障管理)
   'fm.start':'起始時間',
@@ -356,9 +359,11 @@ export const TwLanguage = {
   'sm.smDownload':'下載此排程報表',
   'sm.view_detail':'詳細查看此排程',
   'sm.delItem':'刪除此排程',
-  'sm.fmReport':'產出故障管理報表',
-  'sm.pmReport':'產出效能管理報表',
-  'sm.sfUpdate':'軟體更新',
+  'sm.sfReport':'產出軟體管理報表', // 4
+  'sm.fmReport':'產出故障管理報表', // 3
+  'sm.pmReport':'產出效能管理報表', // 2
+  'sm.caReport':'產出配置稽核報表', // 1
+  'sm.sfUpdate':'軟體更新',        // 0
   
   // Log Management (日誌管理)  @10/31 add by yuchen
   'LogLists': '日誌列表',

--- a/src/app/shared/local-files/Schedule/For_queryJobTicketList.ts
+++ b/src/app/shared/local-files/Schedule/For_queryJobTicketList.ts
@@ -14,7 +14,7 @@
             "tickettype": "0",
             "ticketstatus": "0",
             "executedtype": "0",
-            "executedtime": "2024-03-15 19:00:00",
+            "executedtime": "2024-03-09 19:00:00",
             "jobticket": "0",
             "ticketresult": ""
           },
@@ -22,9 +22,9 @@
             "id": "3fadc30352144dc8a6d4",
             "fieldid": "aa520ec8e5074f54b77d",
             "tickettype": "2",
-            "ticketstatus": "0",
+            "ticketstatus": "1",
             "executedtype": "1",
-            "executedtime": "2024-03-15 13:00:00",
+            "executedtime": "2024-03-16 13:00:00",
             "jobticket": "0",
             "ticketresult": ""
           },
@@ -32,9 +32,9 @@
             "id": "7edf1bea0919445eb89d",
             "fieldid": "aa520ec8e5074f54b77d",
             "tickettype": "4",
-            "ticketstatus": "0",
+            "ticketstatus": "2",
             "executedtype": "1",
-            "executedtime": "2024-03-15 10:00:00",
+            "executedtime": "2024-03-14 10:00:00",
             "jobticket": "0",
             "ticketresult": ""
           },
@@ -42,7 +42,7 @@
             "id": "f7259488c98645bebf7e",
             "fieldid": "aa520ec8e5074f54b77d",
             "tickettype": "3",
-            "ticketstatus": "0",
+            "ticketstatus": "1",
             "executedtype": "0",
             "executedtime": "2024-03-15 10:00:00",
             "jobticket": "0",
@@ -54,7 +54,7 @@
             "tickettype": "1",
             "ticketstatus": "0",
             "executedtype": "0",
-            "executedtime": "2024-03-15 09:35:00",
+            "executedtime": "2024-03-11 09:35:00",
             "jobticket": "0",
             "ticketresult": ""
           },
@@ -62,9 +62,9 @@
             "id": "af0c1fc4c90b4205a3ca",
             "fieldid": "f769da087f2044e7a0d7",
             "tickettype": "2",
-            "ticketstatus": "0",
+            "ticketstatus": "2",
             "executedtype": "0",
-            "executedtime": "2024-03-15 11:40:00",
+            "executedtime": "2024-03-13 11:40:00",
             "jobticket": "0",
             "ticketresult": ""
           }


### PR DESCRIPTION
1. html 上新增判定排程類別機制
2. 中英語言檔 - 新增排程 5 種類別名稱
3. 調整排程列表 local files 以便於顯示