### PR TITLE
更新 BS, schedule Mgmt 兩主頁面顯示機制

### DIFF
--- a/src/app/bs-management/bs-management.component.html
+++ b/src/app/bs-management/bs-management.component.html
@@ -27,25 +27,41 @@
       </tr>
     </thead>
     <tbody>
-      <tr
-        *ngFor="let BS of bsList.basestation | paginate: { itemsPerPage: pageSize, currentPage: p, totalItems: totalItems, id: 'display' } ">
-        <td>{{ BS.name }}</td>
-        <td>{{ BS.bstype === 1 ? 'A' : 'D' }}</td>
-        <td>1</td>
-        <td>{{ BS.description }}</td>
-        <td>{{ BS.fieldName }}</td>
-        <td class="icon">
-          <label *ngIf=" BS.status === 0 " class="grayLight"></label>
-          <label *ngIf=" BS.status === 1 " class="redLight"></label>
-          <label *ngIf=" BS.status === 2 " class="greenLight"></label>
-        </td>
-        <td class="icon">
-          <mat-icon tooltip="{{ languageService.i18n['BS.view'] }}" (click)="viewPage( BS )">remove_red_eye</mat-icon>
-        </td>
-        <td class="icon">
-          <mat-icon tooltip="{{ languageService.i18n['BS.delete'] }}" (click)="openDeleteModal( BS )">delete_forever</mat-icon>
-        </td>
-      </tr>
+
+      <!-- 當數據正在加載時顯示進度條 -->
+      <ng-container *ngIf="isGetQueryBsListLoading">
+        <tr>
+          <td colspan="6">
+            <div class="progress-spinner-container">
+              <!-- 指示器大小設置 -->
+              <mat-progress-spinner class="custom-spinner-color" mode="indeterminate" [diameter]="90"></mat-progress-spinner>
+            </div>
+          </td>
+        </tr>
+      </ng-container>
+
+      <!-- 加載完成後顯示 BS 列表 數據 -->
+      <ng-container *ngIf="!isGetQueryBsListLoading">
+        <tr
+          *ngFor="let BS of bsList.basestation | paginate: { itemsPerPage: pageSize, currentPage: p, totalItems: totalItems, id: 'display' } ">
+          <td>{{ BS.name }}</td>
+          <td>{{ BS.bstype === 1 ? 'A' : 'D' }}</td>
+          <td>{{ BS.cellCount }}</td>
+          <td>{{ BS.description }}</td>
+          <td>{{ BS.fieldName }}</td>
+          <td class="icon">
+            <label *ngIf=" BS.status === 0 " class="grayLight"></label>
+            <label *ngIf=" BS.status === 1 " class="redLight"></label>
+            <label *ngIf=" BS.status === 2 " class="greenLight"></label>
+          </td>
+          <td class="icon">
+            <mat-icon tooltip="{{ languageService.i18n['BS.view'] }}" (click)="viewPage( BS )">remove_red_eye</mat-icon>
+          </td>
+          <td class="icon">
+            <mat-icon tooltip="{{ languageService.i18n['BS.delete'] }}" (click)="openDeleteModal( BS )">delete_forever</mat-icon>
+          </td>
+        </tr>
+      </ng-container>
     </tbody>
   </table>
 </div>

--- a/src/app/bs-management/bs-management.component.html
+++ b/src/app/bs-management/bs-management.component.html
@@ -43,7 +43,7 @@
       <!-- 加載完成後顯示 BS 列表 數據 -->
       <ng-container *ngIf="!isGetQueryBsListLoading">
         <tr
-          *ngFor="let BS of bsList.basestation | paginate: { itemsPerPage: pageSize, currentPage: p, totalItems: totalItems, id: 'display' } ">
+          *ngFor="let BS of bsList.basestation | paginate: { itemsPerPage: pageSize, currentPage: p, totalItems: totalItems, id: 'PageDisplay_of_bsList' } ">
           <td>{{ BS.name }}</td>
           <td>{{ BS.bstype === 1 ? 'A' : 'D' }}</td>
           <td>{{ BS.cellCount }}</td>
@@ -66,7 +66,7 @@
   </table>
 </div>
 <pagination-controls (pageChange)="pageChanged($event)" screenReaderPaginationLabel="Pagination" previousLabel=""
-  nextLabel="" id="display">
+  nextLabel="" id="PageDisplay_of_bsList">
 </pagination-controls>
 
 

--- a/src/app/bs-management/bs-management.component.scss
+++ b/src/app/bs-management/bs-management.component.scss
@@ -17,6 +17,19 @@ tbody tr td {
   text-align: center;
 }
 
+// Spinner 居中並設定大小
+.progress-spinner-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 90px; 
+}
+
+// 設定進度調 (Spinner) 的顏色
+::ng-deep .mat-progress-spinner circle {
+  stroke: #7cbaec !important;
+}
+
 input[type="file"] {
   outline: 0;
 }

--- a/src/app/bs-management/bs-management.component.ts
+++ b/src/app/bs-management/bs-management.component.ts
@@ -137,7 +137,7 @@ export class BSManagementComponent implements OnInit {
   bsList: BSList = {} as BSList;   // @2024/03/19 Add
   isGetQueryBsListLoading = false; // 用於表示加載 BS List 的 flag，初始設置為 false @2024/03/19 Add for Progress Spinner
 
-  // @2024/03/19 Add
+  // @2024/03/21 Update
   // Get the BS List in the O1 System
   getQueryBsList() {
     console.log( 'getQueryBsList() - Start' );       // getQueryBsList() 啟動 
@@ -189,6 +189,38 @@ export class BSManagementComponent implements OnInit {
 
   queryBsListDeal() {
     this.totalItems = this.bsList.basestation.length;
+  
+    // 遍歷 basestation 陣列
+    this.bsList.basestation.forEach(bs => {
+      // 如果 bstype 為 1
+      if ( bs.bstype === 1 ) {
+        // 設置 cellCount 為 1
+        bs.cellCount = 1;
+      } else if ( bs.bstype === 2 ) {
+        // 如果 bstype 為 2，需要遍歷 components 物件
+        let cellCount = 0;
+        for ( const compKey in bs.components ) {
+          const compVal = bs.components[compKey];
+          for ( const innerKey in compVal ) {
+            // 取得內層陣列的長度,即 cell 數量
+            cellCount += compVal[innerKey].length;
+          }
+        }
+        // 設置 cellCount
+        bs.cellCount = cellCount;
+      }
+    });
+  
+    // 使用 setTimeout 設定一個定時刷新
+    // 如當前頁面是第一頁，則定時刷新 BS 列表
+    this.refreshTimeout = window.setTimeout(() => {
+      if (this.p === 1) {
+        console.log(`page[${this.p}] ===> refresh.`);
+        this.getQueryBsList(); // 刷新 BS 列表
+      } else {
+        console.log(`page[${this.p}] ===> no refresh.`);
+      }
+    }, 10000); // 設定 10000 ms 後執行
   }
 
 

--- a/src/app/field-management/field-management.component.scss
+++ b/src/app/field-management/field-management.component.scss
@@ -109,6 +109,7 @@ mat-stepper {
   width: 100px;  // 進度調的寬度
   height: 100px; // 進度調的高度
 }
+
 ::ng-deep #fieldCreationWindow .next button {
   background-color: #4e92ff;
   color: #fff;

--- a/src/app/schedule-management/schedule-management.component.html
+++ b/src/app/schedule-management/schedule-management.component.html
@@ -1,9 +1,9 @@
-<h5>{{languageService.i18n['index.menu_scheduleMgr']}}
-  <mat-icon tooltip="{{languageService.i18n['sm.create']}}" (click)="openCreateModal()">add</mat-icon>
+<h5>{{ languageService.i18n['index.menu_scheduleMgr'] }}
+  <mat-icon tooltip="{{ languageService.i18n['sm.create'] }}" (click)="openCreateModal()">add</mat-icon>
 </h5>
   <form [formGroup]="searchForm">
     <div class="filter">
-      <span><label>{{languageService.i18n['sm.th_state']}}</label>
+      <span><label>{{ languageService.i18n['sm.th_state'] }}</label>
         <input type="text"formControlName="firm">
       </span>
 

--- a/src/app/schedule-management/schedule-management.component.html
+++ b/src/app/schedule-management/schedule-management.component.html
@@ -55,12 +55,11 @@
             <label *ngIf=" schedule.tickettype === '4' ">{{ languageService.i18n['sm.sfReport'] }}</label>
           </td>
           <td class="icon">
-            <label *ngIf=" schedule.ticketstatus === '0' " class="grayLight"></label>
-            <label *ngIf=" schedule.ticketstatus === '1' " class="redLight"></label>
-            <label *ngIf=" schedule.ticketstatus === '2' " class="greenLight"></label>
+            <label [class]="getTicketStatusInfo( schedule ).icon"></label>
+            <label>{{ getTicketStatusInfo( schedule ).message }}</label>
           </td>
           <td class="icon">
-            <mat-icon tooltip="{{ languageService.i18n['sm.smDownload'] }}" (click)="openProvisionModal( schedule )"> download_for_offline </mat-icon>
+            <mat-icon *ngIf="schedule.ticketresult" tooltip="{{ languageService.i18n['sm.smDownload'] }}" (click)="openProvisionModal(schedule)">download_for_offline</mat-icon>
           </td>
           <td class="icon">
             <mat-icon tooltip="{{ languageService.i18n['sm.view_detail'] }}" (click)="viewScheduleDetailInfo( schedule )"> remove_red_eye </mat-icon>

--- a/src/app/schedule-management/schedule-management.component.html
+++ b/src/app/schedule-management/schedule-management.component.html
@@ -25,36 +25,53 @@
       </tr>
     </thead>
     <tbody>
-      <tr *ngFor="let schedule of scheduleList.jobticket | paginate: { 
-                    itemsPerPage: pageSize,
-                     currentPage: p, 
-                      totalItems: totalItems, 
-                              id: 'PageDisplay_of_scheduleList'
-        };">
-        <td>{{ schedule.executedtime }}</td>
-        <td>
-          <label *ngIf=" schedule.tickettype === '0' ">{{ languageService.i18n['sm.sfUpdate'] }}</label>
-          <label *ngIf=" schedule.tickettype === '1' ">{{ languageService.i18n['sm.caReport'] }}</label>
-          <label *ngIf=" schedule.tickettype === '2' ">{{ languageService.i18n['sm.pmReport'] }}</label>
-          <label *ngIf=" schedule.tickettype === '3' ">{{ languageService.i18n['sm.fmReport'] }}</label>
-          <label *ngIf=" schedule.tickettype === '4' ">{{ languageService.i18n['sm.sfReport'] }}</label>
-        </td>
-        <td class="icon">
-          <label *ngIf=" schedule.ticketstatus === '0' " class="grayLight"></label>
-          <label *ngIf=" schedule.ticketstatus === '1' " class="redLight"></label>
-          <label *ngIf=" schedule.ticketstatus === '2' " class="greenLight"></label>
-        </td>
-        <td class="icon">
-          <mat-icon tooltip="{{ languageService.i18n['sm.smDownload'] }}" (click)="openProvisionModal( schedule )"> download_for_offline </mat-icon>
-        </td>
-        <td class="icon">
-          <mat-icon tooltip="{{ languageService.i18n['sm.view_detail'] }}" (click)="viewScheduleDetailInfo( schedule )"> remove_red_eye </mat-icon>
-        </td>
-        <td class="icon">
-          <mat-icon tooltip="{{ languageService.i18n['sm.delItem'] }}" (click)="openDeleteModal( schedule )"> delete_forever </mat-icon>
-        </td>
-      </tr>
+
+      <!-- 當數據正在加載時顯示進度條 -->
+      <ng-container *ngIf="isLoadingScheduleList">
+        <tr>
+          <td colspan="6">
+            <div class="progress-spinner-container">
+              <!-- 指示器大小設置 -->
+              <mat-progress-spinner class="custom-spinner-color" mode="indeterminate" [diameter]="90"></mat-progress-spinner>
+            </div>
+          </td>
+        </tr>
+      </ng-container>
+
+      <!-- 加載完成後顯示 排程列表 數據 -->
+      <ng-container *ngIf="!isLoadingScheduleList">
+        <tr *ngFor="let schedule of scheduleList.jobticket | paginate: { 
+                      itemsPerPage: pageSize,
+                      currentPage: p, 
+                        totalItems: totalItems, 
+                                id: 'PageDisplay_of_scheduleList'
+          };">
+          <td>{{ schedule.executedtime }}</td>
+          <td>
+            <label *ngIf=" schedule.tickettype === '0' ">{{ languageService.i18n['sm.sfUpdate'] }}</label>
+            <label *ngIf=" schedule.tickettype === '1' ">{{ languageService.i18n['sm.caReport'] }}</label>
+            <label *ngIf=" schedule.tickettype === '2' ">{{ languageService.i18n['sm.pmReport'] }}</label>
+            <label *ngIf=" schedule.tickettype === '3' ">{{ languageService.i18n['sm.fmReport'] }}</label>
+            <label *ngIf=" schedule.tickettype === '4' ">{{ languageService.i18n['sm.sfReport'] }}</label>
+          </td>
+          <td class="icon">
+            <label *ngIf=" schedule.ticketstatus === '0' " class="grayLight"></label>
+            <label *ngIf=" schedule.ticketstatus === '1' " class="redLight"></label>
+            <label *ngIf=" schedule.ticketstatus === '2' " class="greenLight"></label>
+          </td>
+          <td class="icon">
+            <mat-icon tooltip="{{ languageService.i18n['sm.smDownload'] }}" (click)="openProvisionModal( schedule )"> download_for_offline </mat-icon>
+          </td>
+          <td class="icon">
+            <mat-icon tooltip="{{ languageService.i18n['sm.view_detail'] }}" (click)="viewScheduleDetailInfo( schedule )"> remove_red_eye </mat-icon>
+          </td>
+          <td class="icon">
+            <mat-icon tooltip="{{ languageService.i18n['sm.delItem'] }}" (click)="openDeleteModal( schedule )"> delete_forever </mat-icon>
+          </td>
+        </tr>
+      </ng-container>
     </tbody>
+    
   </table>
 </div>
 <pagination-controls

--- a/src/app/schedule-management/schedule-management.component.scss
+++ b/src/app/schedule-management/schedule-management.component.scss
@@ -1,4 +1,3 @@
-
 table {
   //width: 100%;
   max-width: 97.65%;
@@ -35,6 +34,19 @@ tbody tr td {
   height: 1em;
   border-radius: 50em;
   background-color: #7e7e7e;
+}
+
+// Spinner 居中並設定大小
+.progress-spinner-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 90px; 
+}
+
+// 設定進度調 (Spinner) 的顏色
+::ng-deep .mat-progress-spinner circle {
+  stroke: #7cbaec !important;
 }
 
 input[type="file"] {

--- a/src/app/schedule-management/schedule-management.component.scss
+++ b/src/app/schedule-management/schedule-management.component.scss
@@ -16,6 +16,7 @@ tbody tr td {
   text-align: center;
 }
 
+// 成功 - ticketstatus = 3
 .greenLight {
   display: inline-block;
   width: 1em;
@@ -24,16 +25,36 @@ tbody tr td {
   background-color: #89d135;
 }
 
+// 失敗 - ticketstatus = 4
 .redLight {
   display: inline-block;
 }
 
+// 排程中、排程中(每天) - ticketstatus = 1
 .grayLight {
   display: inline-block;
   width: 1em;
   height: 1em;
   border-radius: 50em;
   background-color: #7e7e7e;
+}
+
+// 部份成功 - ticketstatus = 5
+.yellowLight {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  border-radius: 50em;
+  background-color: rgb(243, 192, 73);
+}
+
+// 進行中 - ticketstatus = 2
+.blueLight {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  border-radius: 50em;
+  background-color: rgb(0, 67, 200);
 }
 
 // Spinner 居中並設定大小

--- a/src/app/schedule-management/schedule-management.component.ts
+++ b/src/app/schedule-management/schedule-management.component.ts
@@ -164,6 +164,7 @@ export class ScheduleManagementComponent implements OnInit {
 
       this.isLoadingScheduleList = false; // Local 模式下,數據加載快速完成,直接設置為 false
     } else {
+      
       // 非 Local 模式: 通過 API 從服務器獲取數據
       this.queryJobTicketList = this.API_Schedule.queryJobTicketList().subscribe({
         next: ( res ) => {
@@ -172,18 +173,20 @@ export class ScheduleManagementComponent implements OnInit {
           console.log( 'Get the ScheduleList:', res );
 
           this.scheduleList = res; // 更新排程列表數據
-
           this.scheduleListDeal();
+          console.log( '排程列表資訊\n( BS List ):', this.scheduleList ); // 取得的 Schedule List 資訊 ( Obtained Schedule List information )
+          
+
+          this.isLoadingScheduleList = false; // 數據加載完成
         },
         error: ( error ) => {
           // 請求出現錯誤
-          console.error('Error fetching schedule list:', error);
+          console.error( 'Error fetching schedule list:', error );
           this.isLoadingScheduleList = false; // 出錯時設置加載標誌為 false
         },
         complete: () => {
           // 數據流處理完成（無論成功或失敗）
-          console.log('Schedule list fetch completed');
-          this.isLoadingScheduleList = false; // 數據加載完成
+          console.log( 'Schedule list fetch completed' );
         }
       });
     }
@@ -193,6 +196,20 @@ export class ScheduleManagementComponent implements OnInit {
 
   scheduleListDeal() {
     this.totalItems = this.scheduleList.jobticket.length;
+
+    // 使用 setTimeout 設定一個定時刷新
+    // 如當前頁面是第一頁，則定時刷新排程列表
+    this.refreshTimeout = window.setTimeout(() => {
+      if ( this.p === 1 ) {
+
+        console.log(`page[${this.p}] ===> refresh.`);
+        this.getQueryJobTicketList(); // 更新排程訊息( 可選 )
+
+      } else {
+
+        console.log(`page[${this.p}] ===> no refresh.`);
+      }
+    }, 10000 ); // 設定 10000 ms 後執行
   }
 
 

--- a/src/app/schedule-management/schedule-management.component.ts
+++ b/src/app/schedule-management/schedule-management.component.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { Component, OnInit, SimpleChanges , TemplateRef, ViewChild } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { Router } from '@angular/router';
@@ -121,6 +121,10 @@ export class ScheduleManagementComponent implements OnInit {
     this.sessionId = this.commonService.getSessionId();
     this.afterSearchForm = _.cloneDeep( this.searchForm );
     this.getQueryJobTicketList();
+
+    this.languageService.languageChanged.subscribe(
+      (language) => this.updateTicketStatusInfo()
+    );
   }
 
   ngOnDestroy() {
@@ -128,7 +132,6 @@ export class ScheduleManagementComponent implements OnInit {
     if (this.querySoftwareScpt) this.querySoftwareScpt.unsubscribe();
     if (this.querySWAdvanceSearchScpt) this.querySWAdvanceSearchScpt.unsubscribe();
   }
-
 
   softwareLists: SoftwareLists = {} as SoftwareLists;
   componentList: ComponentLists = {} as ComponentLists;
@@ -164,7 +167,7 @@ export class ScheduleManagementComponent implements OnInit {
 
       this.isLoadingScheduleList = false; // Local 模式下,數據加載快速完成,直接設置為 false
     } else {
-      
+
       // 非 Local 模式: 通過 API 從服務器獲取數據
       this.queryJobTicketList = this.API_Schedule.queryJobTicketList().subscribe({
         next: ( res ) => {
@@ -213,7 +216,57 @@ export class ScheduleManagementComponent implements OnInit {
   }
 
 
+// 控制顯示排程狀態的圖案與訊息 ↓
+
+  // @2024/03/21 Add
+  // 用於存儲排程狀態對應的圖示和訊息
+  ticketStatusInfo = [
+    { icon: 'grayLight', message: this.languageService.i18n['sm.jobSchedulingString'] },
+    { icon: 'grayLight', message: this.languageService.i18n['sm.jobSchedulingString'] + ' (' + this.languageService.i18n['sm.jobDailyString'] + ')' },
+    { icon: 'blueLight', message: this.languageService.i18n['sm.jobOnGoingString'] },
+    { icon: 'greenLight', message: this.languageService.i18n['sm.jobSuccessString'] },
+    { icon: 'redLight', message: this.languageService.i18n['sm.jobFailString'] },
+    { icon: 'yellowLight', message: this.languageService.i18n['sm.jobPartialSuccessString'] }
+  ];
+
+  // @2024/03/21 Add
+  // 根據排程狀態獲取對應的圖示和訊息
+  getTicketStatusInfo( schedule: Schedule ) {
+    const ticketStatus = parseInt( schedule.ticketstatus );
+    const executedType = parseInt( schedule.executedtype );
+
+    if ( ticketStatus === 0 || ticketStatus === 1 ) {
+      if ( executedType === 1 ) {
+        return this.ticketStatusInfo[1];
+      } else if ( executedType === 2 ) {
+        return { icon: 'grayLight', message: this.languageService.i18n['sm.jobSchedulingString'] + ' (' + this.languageService.i18n['sm.jobWeeklyString'] + ')' };
+      } else if ( executedType === 3 ) {
+        return { icon: 'grayLight', message: this.languageService.i18n['sm.jobSchedulingString'] + ' (' + this.languageService.i18n['sm.jobMonthlyString'] + ')' };
+      }
+    }
+
+    return this.ticketStatusInfo[ticketStatus];
+  }
+
+  // @2024/03/21 Add
+  // 用於更新根據排程狀態獲取對應的圖示和訊息
+  updateTicketStatusInfo() {
+    this.ticketStatusInfo = [
+      { icon: 'grayLight', message: this.languageService.i18n['sm.jobSchedulingString'] },
+      { icon: 'grayLight', message: this.languageService.i18n['sm.jobSchedulingString'] + ' (' + this.languageService.i18n['sm.jobDailyString'] + ')' },
+      { icon: 'blueLight', message: this.languageService.i18n['sm.jobOnGoingString'] },
+      { icon: 'greenLight', message: this.languageService.i18n['sm.jobSuccessString'] },
+      { icon: 'redLight', message: this.languageService.i18n['sm.jobFailString'] },
+      { icon: 'yellowLight', message: this.languageService.i18n['sm.jobPartialSuccessString'] }
+    ];
+  }
+
+// 控制顯示排程狀態的圖案與訊息 ↑
+
+
+
   selectSchedule!: Schedule;  // 用於存儲當前選中的排程訊息 @2024/03/17 Add
+  
   /** @2024/03/17 Add
    *  導航到選定的排程詳細資訊頁面。
    *  @param schedule 從排程列表中選擇的排程物件。

--- a/src/app/shared/interfaces/BS/For_queryBsList.ts
+++ b/src/app/shared/interfaces/BS/For_queryBsList.ts
@@ -1,5 +1,5 @@
 
-// @2024/01/16 Add by yuchen
+// @2024/03/21 Update by yuchen
 // 描述系統內所有 BS 的列表
 
 export interface BSList {
@@ -16,7 +16,7 @@ export interface Basestation {
     position: string;
     description: string; // 基站地點說明
     bstype: number;
-    components: {};
+    components: { [key: string]: any }; // 定義為帶索引簽名的物件,鍵為字符串,值可以是任意類型,用於支援使用字符串索引訪問和修改屬性
     status: number;
     gNBId: number;
     gNBIdLength: number;
@@ -24,6 +24,8 @@ export interface Basestation {
     laston: string;
     lastoff: string;
 
+    cellCount?: number; // 記錄 cell 數用
+    
     selected?: boolean; // 用於決定 BS list 每列 BS 對應到的 CheckBox 是否要顯示被選擇或未選擇
 }
   

--- a/src/app/shared/interfaces/Schedule/For_queryJobTicketInfo.ts
+++ b/src/app/shared/interfaces/Schedule/For_queryJobTicketInfo.ts
@@ -1,7 +1,7 @@
 
-// @2024/03/15 Add
-// 用於儲存排程資訊
-export interface ScheduleInfo {
+  // @2024/03/21 Update
+  // 用於儲存排程資訊
+  export interface ScheduleInfo {
     id: string;
     fieldid: string;
     fieldname: string;
@@ -10,40 +10,57 @@ export interface ScheduleInfo {
     executedtype: string;
     executedtime: string;
     jobticket: string;
-    ticketinfo: Ticketinfo[] | Ticketinfo2[] | Ticketinfo3[] | Ticketinfo4;
+    ticketinfo: Ticketinfo[] | Ticketinfo2[] | Ticketinfo3[] | Ticketinfo4[] | Ticketinfo5;
     ticketresult: string;
   }
+  
 
-  // @2024/03/15 Add
-  // 用於儲存單一排程細項資訊 - type 4 
-  export interface Ticketinfo4 {
+  // @2024/03/21 Add
+  // 用於儲存單一排程細項資訊 - type 5
+  export interface Ticketinfo5 {
     fieldsnapshotid: string;
     fieldsnapshotname: string;
   }
-
-  // @2024/03/15 Add
-  // 用於儲存單一排程細項資訊 - type 3
-  export interface Ticketinfo3 {
+  
+  // @2024/03/21 Add
+  // 用於儲存單一排程細項資訊 - type 4
+  export interface Ticketinfo4 {
     fieldId: string;
     start: string;
     end: string;
     iscustomized: number;
   }
 
-  // @2024/03/15 Add
+  // @2024/03/21 Add
+  // 用於儲存單一排程細項資訊 - type 3
+  export interface Ticketinfo3 {
+    fieldId: string;
+    start: string;
+    end: string;
+    iscustomized: number;
+    customizedkpi: { [key: string]: any }; 
+  }
+  
+  // @2024/03/21 Add
   // 用於儲存單一排程細項資訊 - type 2
   export interface Ticketinfo2 {
+    fieldId: string;
+    start: string;
+    end: string;
+  }
+
+  // @2024/03/21 Add
+  // 用於儲存單一排程細項資訊 - type 1
+  export interface Ticketinfo {
     bscompid: string;
     bscompname: string;
     uploadid: string;
     currentversion: string;
     upgradeversion: string;
+    installlog: Installlog[];
   }
-
-  // @2024/03/15 Add
-  // 用於儲存單一排程細項資訊 - type 1
-  export interface Ticketinfo {
-    fieldId: string;
-    start: string;
-    end: string;
+  
+  export interface Installlog {
+    Download: string;
+    Install: string;
   }

--- a/src/app/shared/language-models/en-language.ts
+++ b/src/app/shared/language-models/en-language.ts
@@ -369,11 +369,20 @@ export const Enlanguage = {
   'sm.smDownload':'Download report of this schedule',
   'sm.view_detail':'View this schedule in detail',
   'sm.delItem':'Delete this schedule',
-  'sm.sfReport':'Software Management Report',    // 4
-  'sm.fmReport':'Fault Management Report',       // 3
-  'sm.pmReport':'Performance Management Report', // 2
-  'sm.caReport':'Config Audit Report',           // 1
-  'sm.sfUpdate':'Software Update',               // 0
+  'sm.sfReport':'Software Management Report',    // tickettype = 4
+  'sm.fmReport':'Fault Management Report',       // tickettype = 3
+  'sm.pmReport':'Performance Management Report', // tickettype = 2
+  'sm.caReport':'Config Audit Report',           // tickettype = 1
+  'sm.sfUpdate':'Software Update',               // tickettype = 0
+
+  'sm.jobPartialSuccessString':'Partially Success', // ticketstatus = 5
+  'sm.jobFailString':'Failed',                      // ticketstatus = 4
+  'sm.jobSuccessString':'Success',                  // ticketstatus = 3
+  'sm.jobOnGoingString':'On Going',                 // ticketstatus = 2
+  'sm.jobSchedulingString':'Scheduling',            // ticketstatus = 1 | 0
+  'sm.jobDailyString':'Daily',                      // executedtype = 1
+  'sm.jobWeeklyString':'Weekly',                    // executedtype = 2
+  'sm.jobMonthlyString':'Monthly',                  // executedtype = 3
 
   'sm.info':'Schedule Information', 
 

--- a/src/app/shared/language-models/tw-language.ts
+++ b/src/app/shared/language-models/tw-language.ts
@@ -367,11 +367,20 @@ export const TwLanguage = {
   'sm.smDownload':'下載此排程報表',
   'sm.view_detail':'詳細查看此排程',
   'sm.delItem':'刪除此排程',
-  'sm.sfReport':'產出軟體管理報表', // 4
-  'sm.fmReport':'產出故障管理報表', // 3
-  'sm.pmReport':'產出效能管理報表', // 2
-  'sm.caReport':'產出配置稽核報表', // 1
-  'sm.sfUpdate':'軟體更新',        // 0
+  'sm.sfReport':'產出軟體管理報表', // tickettype = 4
+  'sm.fmReport':'產出故障管理報表', // tickettype = 3
+  'sm.pmReport':'產出效能管理報表', // tickettype = 2
+  'sm.caReport':'產出配置稽核報表', // tickettype = 1
+  'sm.sfUpdate':'軟體更新',         // tickettype = 0
+
+  'sm.jobPartialSuccessString':'部份成功', // ticketstatus = 5
+  'sm.jobFailString':'失敗',               // ticketstatus = 4
+  'sm.jobSuccessString':'成功',            // ticketstatus = 3
+  'sm.jobOnGoingString':'進行中',          // ticketstatus = 2
+  'sm.jobSchedulingString':'排程中',       // ticketstatus = 1 | 0
+  'sm.jobDailyString':'每天',              // executedtype = 1
+  'sm.jobWeeklyString':'每週',             // executedtype = 2
+  'sm.jobMonthlyString':'每月',            // executedtype = 3
 
   'sm.info':'排程資訊', 
   

--- a/src/app/shared/language-models/tw-language.ts
+++ b/src/app/shared/language-models/tw-language.ts
@@ -196,7 +196,7 @@ export const TwLanguage = {
 
   'BS.name':'基站名稱',
   'BS.type':'基站類型',
-  'BS.cellCount':'Cell數',
+  'BS.cellCount':'Cell 數',
   'BS.description':'基站地點說明',
   'BS.belongField':'隸屬場域',
   'BS.status':'連線狀態',

--- a/src/app/shared/local-files/Schedule/For_queryJobTicketInfo.ts
+++ b/src/app/shared/local-files/Schedule/For_queryJobTicketInfo.ts
@@ -2,120 +2,482 @@
  // Interfaces of ScheduleInfo @2024/03/15 Add
  import { ScheduleInfo } from './../../interfaces/Schedule/For_queryJobTicketInfo'; 
 
- // Local Files for general ScheduleInfo @2024/03/15 Add
+ // Local Files for general ScheduleInfo @2024/03/21 Update
  export class localScheduleInfo {
 
     // For getQueryJobTicketInfo() Get local queryJobTicketInfo
     scheduleInfo_local: ScheduleInfo[] = [
-        {
-          "id": "9e75da718d3a4739b517",
-          "fieldid": "aa520ec8e5074f54b77d",
-          "fieldname": "ITRI2",
-          "tickettype": "0",
-          "ticketstatus": "0",
-          "executedtype": "0",
-          "executedtime": "2024-03-15 19:00:00",
-          "jobticket": "0",
-          "ticketinfo": [
-            {
-              "bscompid": "768ba7fe80cd4360bbb5",
-              "bscompname": "bscom15",
-              "uploadid": "747e019131284bd3a020",
-              "currentversion": "",
-              "upgradeversion": "1.0"
-            }
-          ],
-          "ticketresult": ""
+      {
+        "id": "59d1af12c92344259217",
+        "fieldid": "aa520ec8e5074f54b77d",
+        "fieldname": "ITRI2",
+        "tickettype": "1",
+        "ticketstatus": "0",
+        "executedtype": "3",
+        "executedtime": "2024-04-03 05:00:00",
+        "jobticket": "0",
+        "ticketinfo": {
+          "fieldsnapshotid": "170bf2b11b794827b820",
+          "fieldsnapshotname": "123132"
         },
-        {
-          "id": "3fadc30352144dc8a6d4",
-          "fieldid": "aa520ec8e5074f54b77d",
-          "fieldname": "ITRI2",
-          "tickettype": "2",
-          "ticketstatus": "0",
-          "executedtype": "1",
-          "executedtime": "2024-03-15 13:00:00",
-          "jobticket": "0",
-          "ticketinfo": [
-            {
-              "fieldId": "aa520ec8e5074f54b77d",
-              "start": "2024-03-14 00:00",
-              "end": "2024-03-14 23:59",
-              "iscustomized": 0
-            }
-          ],
-          "ticketresult": ""
-        },
-        {
-          "id": "7edf1bea0919445eb89d",
-          "fieldid": "aa520ec8e5074f54b77d",
-          "fieldname": "ITRI2",
-          "tickettype": "4",
-          "ticketstatus": "0",
-          "executedtype": "1",
-          "executedtime": "2024-03-15 10:00:00",
-          "jobticket": "0",
-          "ticketinfo": [
-            {
-              "fieldId": "aa520ec8e5074f54b77d",
-              "start": "2024-03-14 00:00",
-              "end": "2024-03-14 23:59"
-            }
-          ],
-          "ticketresult": ""
-        },
-        {
-          "id": "f7259488c98645bebf7e",
-          "fieldid": "aa520ec8e5074f54b77d",
-          "fieldname": "ITRI2",
-          "tickettype": "3",
-          "ticketstatus": "0",
-          "executedtype": "0",
-          "executedtime": "2024-03-15 10:00:00",
-          "jobticket": "0",
-          "ticketinfo": [
-            {
-              "fieldId": "aa520ec8e5074f54b77d",
-              "start": "2024-03-01 00:00",
-              "end": "2024-03-14 15:00"
-            }
-          ],
-          "ticketresult": ""
-        },
-        {
-          "id": "6fd8e7652a7c4cd6a47e",
-          "fieldid": "aa520ec8e5074f54b77d",
-          "fieldname": "ITRI2",
-          "tickettype": "1",
-          "ticketstatus": "0",
-          "executedtype": "0",
-          "executedtime": "2024-03-15 09:35:00",
-          "jobticket": "0",
-          "ticketinfo": {
-            "fieldsnapshotid": "170bf2b11b794827b820",
-            "fieldsnapshotname": "123132"
+        "ticketresult": ""
+      },
+      {
+        "id": "7d9834a134bd473faf62",
+        "fieldid": "aa520ec8e5074f54b77d",
+        "fieldname": "ITRI2",
+        "tickettype": "4",
+        "ticketstatus": "0",
+        "executedtype": "2",
+        "executedtime": "2024-03-27 05:00:00",
+        "jobticket": "0",
+        "ticketinfo": [
+          {
+            "fieldId": "aa520ec8e5074f54b77d",
+            "start": "2024-03-20 00:00",
+            "end": "2024-03-26 23:59"
+          }
+        ],
+        "ticketresult": ""
+      },
+      {
+        "id": "3f69e61845f948fca0c8",
+        "fieldid": "aa520ec8e5074f54b77d",
+        "fieldname": "ITRI2",
+        "tickettype": "2",
+        "ticketstatus": "0",
+        "executedtype": "1",
+        "executedtime": "2024-03-22 13:00:00",
+        "jobticket": "0",
+        "ticketinfo": [
+          {
+            "fieldId": "aa520ec8e5074f54b77d",
+            "start": "2024-03-20 00:00:00",
+            "end": "2024-03-20 23:59:59",
+            "iscustomized": 0
+          }
+        ],
+        "ticketresult": ""
+      },
+      {
+        "id": "0a43733eeada462090bc",
+        "fieldid": "aa520ec8e5074f54b77d",
+        "fieldname": "ITRI2",
+        "tickettype": "4",
+        "ticketstatus": "0",
+        "executedtype": "1",
+        "executedtime": "2024-03-22 10:00:00",
+        "jobticket": "0",
+        "ticketinfo": [
+          {
+            "fieldId": "aa520ec8e5074f54b77d",
+            "start": "2024-03-19 00:00:00",
+            "end": "2024-03-19 23:59:59"
+          }
+        ],
+        "ticketresult": ""
+      },
+      {
+        "id": "dd9f0d4919164f8d90d8",
+        "fieldid": "aa520ec8e5074f54b77d",
+        "fieldname": "ITRI2",
+        "tickettype": "3",
+        "ticketstatus": "3",
+        "executedtype": "0",
+        "executedtime": "2024-03-21 14:00:00",
+        "jobticket": "1",
+        "ticketinfo": [
+          {
+            "fieldId": "aa520ec8e5074f54b77d",
+            "start": "2024-03-01 00:00:00",
+            "end": "2024-03-08 00:00:00"
+          }
+        ],
+        "ticketresult": "FM_Report_2024-03-01-00-00-00-2024-03-08-00-00-00.xlsx"
+      },
+      {
+        "id": "b771d42a70df4c6ab247",
+        "fieldid": "e6700d701f8b41f8950e",
+        "fieldname": "ITRI",
+        "tickettype": "0",
+        "ticketstatus": "5",
+        "executedtype": "0",
+        "executedtime": "2024-03-21 13:14:00",
+        "jobticket": "1",
+        "ticketinfo": [
+          {
+            "bscompid": "77566db644d24af3b93f",
+            "bscompname": "bscom12",
+            "uploadid": "747e019131284bd3a020",
+            "currentversion": "0.1.0",
+            "upgradeversion": "1.0",
+            "installlog": [
+              {
+                "Download": "2024-03-21 13:15:04.260041 Download Success 77566db644d24af3b93f",
+                "Install": "2024-03-21 13:15:34.370247 Install Fail 77566db644d24af3b93f"
+              }
+            ]
           },
-          "ticketresult": ""
-        },
-        {
-          "id": "af0c1fc4c90b4205a3ca",
-          "fieldid": "f769da087f2044e7a0d7",
-          "fieldname": "field",
-          "tickettype": "2",
-          "ticketstatus": "0",
-          "executedtype": "0",
-          "executedtime": "2024-03-15 11:40:00",
-          "jobticket": "0",
-          "ticketinfo": [
-            {
-              "fieldId": "f769da087f2044e7a0d7",
-              "start": "2024-03-14 00:00",
-              "end": "2024-03-15 00:00",
-              "iscustomized": 0
+          {
+            "bscompid": "34022d76fefa4bb4a848",
+            "bscompname": "bscom14",
+            "uploadid": "42874896269f4263af0e",
+            "currentversion": "0.1.0",
+            "upgradeversion": "1.0.0",
+            "installlog": [
+              {
+                "Download": "2024-03-21 13:15:40.636214 Download Success 34022d76fefa4bb4a848",
+                "Install": "2024-03-21 13:16:10.753614 Install Fail 34022d76fefa4bb4a848"
+              }
+            ]
+          }
+        ],
+        "ticketresult": ""
+      },
+      {
+        "id": "d1a274f2a2e44507ba61",
+        "fieldid": "aa520ec8e5074f54b77d",
+        "fieldname": "ITRI2",
+        "tickettype": "2",
+        "ticketstatus": "3",
+        "executedtype": "0",
+        "executedtime": "2024-03-21 13:11:00",
+        "jobticket": "1",
+        "ticketinfo": [
+          {
+            "fieldId": "aa520ec8e5074f54b77d",
+            "start": "2024-03-06 00:00:00",
+            "end": "2024-03-21 00:00:00",
+            "iscustomized": 1,
+            "customizedkpi": {
+              "0": {
+                "name": "25121",
+                "describe": "212112",
+                "kpi": "5212121"
+              }
             }
-          ],
-          "ticketresult": ""
-        }
-      ];
+          }
+        ],
+        "ticketresult": "PmReportCustomized-2024-03-21-13-12-19.xlsx"
+      },
+      {
+        "id": "86c1dc7773224f60a040",
+        "fieldid": "aa520ec8e5074f54b77d",
+        "fieldname": "ITRI2",
+        "tickettype": "2",
+        "ticketstatus": "3",
+        "executedtype": "1",
+        "executedtime": "2024-03-21 13:00:00",
+        "jobticket": "1",
+        "ticketinfo": [
+          {
+            "fieldId": "aa520ec8e5074f54b77d",
+            "start": "2024-03-20 00:00:00",
+            "end": "2024-03-20 23:59:59",
+            "iscustomized": 0
+          }
+        ],
+        "ticketresult": "PmReport-2024-03-21-13-00-22.xlsx"
+      },
+      {
+        "id": "857118441dbf4255a5a2",
+        "fieldid": "aa520ec8e5074f54b77d",
+        "fieldname": "ITRI2",
+        "tickettype": "4",
+        "ticketstatus": "4",
+        "executedtype": "1",
+        "executedtime": "2024-03-21 10:00:00",
+        "jobticket": "1",
+        "ticketinfo": [
+          {
+            "fieldId": "aa520ec8e5074f54b77d",
+            "start": "2024-03-19 00:00:00",
+            "end": "2024-03-19 23:59:59"
+          }
+        ],
+        "ticketresult": ""
+      },
+      {
+        "id": "072978190052488e8ed7",
+        "fieldid": "aa520ec8e5074f54b77d",
+        "fieldname": "ITRI2",
+        "tickettype": "2",
+        "ticketstatus": "3",
+        "executedtype": "1",
+        "executedtime": "2024-03-20 13:00:00",
+        "jobticket": "1",
+        "ticketinfo": [
+          {
+            "fieldId": "aa520ec8e5074f54b77d",
+            "start": "2024-03-19 00:00:00",
+            "end": "2024-03-19 23:59:59",
+            "iscustomized": 0
+          }
+        ],
+        "ticketresult": "PmReport-2024-03-20-16-51-23.xlsx"
+      },
+      {
+        "id": "3d01156b231f405ab69a",
+        "fieldid": "aa520ec8e5074f54b77d",
+        "fieldname": "ITRI2",
+        "tickettype": "4",
+        "ticketstatus": "3",
+        "executedtype": "1",
+        "executedtime": "2024-03-20 10:00:00",
+        "jobticket": "1",
+        "ticketinfo": [
+          {
+            "fieldId": "aa520ec8e5074f54b77d",
+            "start": "2024-03-19 00:00:00",
+            "end": "2024-03-19 23:59:59"
+          }
+        ],
+        "ticketresult": "SwmReport-2024-03-20-16-51-46.xlsx"
+      },
+      {
+        "id": "b96b98b1a16344de9cfe",
+        "fieldid": "aa520ec8e5074f54b77d",
+        "fieldname": "ITRI2",
+        "tickettype": "2",
+        "ticketstatus": "3",
+        "executedtype": "1",
+        "executedtime": "2024-03-19 13:00:00",
+        "jobticket": "1",
+        "ticketinfo": [
+          {
+            "fieldId": "aa520ec8e5074f54b77d",
+            "start": "2024-03-18 00:00:00",
+            "end": "2024-03-18 23:59:59",
+            "iscustomized": 0
+          }
+        ],
+        "ticketresult": "PmReport-2024-03-20-16-50-24.xlsx"
+      },
+      {
+        "id": "e5e9a7817e4545c8b24b",
+        "fieldid": "aa520ec8e5074f54b77d",
+        "fieldname": "ITRI2",
+        "tickettype": "4",
+        "ticketstatus": "3",
+        "executedtype": "1",
+        "executedtime": "2024-03-19 10:00:00",
+        "jobticket": "1",
+        "ticketinfo": [
+          {
+            "fieldId": "aa520ec8e5074f54b77d",
+            "start": "2024-03-18 00:00:00",
+            "end": "2024-03-18 23:59:59"
+          }
+        ],
+        "ticketresult": "SwmReport-2024-03-20-16-50-50.xlsx"
+      },
+      {
+        "id": "8e984caa71ce497b8600",
+        "fieldid": "aa520ec8e5074f54b77d",
+        "fieldname": "ITRI2",
+        "tickettype": "2",
+        "ticketstatus": "3",
+        "executedtype": "1",
+        "executedtime": "2024-03-18 13:00:00",
+        "jobticket": "1",
+        "ticketinfo": [
+          {
+            "fieldId": "aa520ec8e5074f54b77d",
+            "start": "2024-03-17 00:00:00",
+            "end": "2024-03-17 23:59:59",
+            "iscustomized": 0
+          }
+        ],
+        "ticketresult": "PmReport-2024-03-20-16-49-29.xlsx"
+      },
+      {
+        "id": "2861ef7ef2a24982ae00",
+        "fieldid": "aa520ec8e5074f54b77d",
+        "fieldname": "ITRI2",
+        "tickettype": "4",
+        "ticketstatus": "3",
+        "executedtype": "1",
+        "executedtime": "2024-03-18 10:00:00",
+        "jobticket": "1",
+        "ticketinfo": [
+          {
+            "fieldId": "aa520ec8e5074f54b77d",
+            "start": "2024-03-17 00:00:00",
+            "end": "2024-03-17 23:59:59"
+          }
+        ],
+        "ticketresult": "SwmReport-2024-03-20-16-49-26.xlsx"
+      },
+      {
+        "id": "ce430c58566d40aca51b",
+        "fieldid": "aa520ec8e5074f54b77d",
+        "fieldname": "ITRI2",
+        "tickettype": "2",
+        "ticketstatus": "3",
+        "executedtype": "1",
+        "executedtime": "2024-03-17 13:00:00",
+        "jobticket": "1",
+        "ticketinfo": [
+          {
+            "fieldId": "aa520ec8e5074f54b77d",
+            "start": "2024-03-16 00:00:00",
+            "end": "2024-03-16 23:59:59",
+            "iscustomized": 0
+          }
+        ],
+        "ticketresult": "PmReport-2024-03-20-16-48-32.xlsx"
+      },
+      {
+        "id": "80d7bdf88585460b9967",
+        "fieldid": "aa520ec8e5074f54b77d",
+        "fieldname": "ITRI2",
+        "tickettype": "4",
+        "ticketstatus": "3",
+        "executedtype": "1",
+        "executedtime": "2024-03-17 10:00:00",
+        "jobticket": "1",
+        "ticketinfo": [
+          {
+            "fieldId": "aa520ec8e5074f54b77d",
+            "start": "2024-03-16 00:00:00",
+            "end": "2024-03-16 23:59:59"
+          }
+        ],
+        "ticketresult": "SwmReport-2024-03-20-16-48-23.xlsx"
+      },
+      {
+        "id": "13bd97bb48b14c4ebca1",
+        "fieldid": "aa520ec8e5074f54b77d",
+        "fieldname": "ITRI2",
+        "tickettype": "2",
+        "ticketstatus": "3",
+        "executedtype": "1",
+        "executedtime": "2024-03-16 13:00:00",
+        "jobticket": "1",
+        "ticketinfo": [
+          {
+            "fieldId": "aa520ec8e5074f54b77d",
+            "start": "2024-03-15 00:00:00",
+            "end": "2024-03-15 23:59:59",
+            "iscustomized": 0
+          }
+        ],
+        "ticketresult": "PmReport-2024-03-20-16-47-24.xlsx"
+      },
+      {
+        "id": "d7ff5b400f57488788e1",
+        "fieldid": "aa520ec8e5074f54b77d",
+        "fieldname": "ITRI2",
+        "tickettype": "4",
+        "ticketstatus": "3",
+        "executedtype": "1",
+        "executedtime": "2024-03-16 10:00:00",
+        "jobticket": "1",
+        "ticketinfo": [
+          {
+            "fieldId": "aa520ec8e5074f54b77d",
+            "start": "2024-03-15 00:00:00",
+            "end": "2024-03-15 23:59:59"
+          }
+        ],
+        "ticketresult": "SwmReport-2024-03-20-16-47-49.xlsx"
+      },
+      {
+        "id": "9e75da718d3a4739b517",
+        "fieldid": "aa520ec8e5074f54b77d",
+        "fieldname": "ITRI2",
+        "tickettype": "0",
+        "ticketstatus": "5",
+        "executedtype": "0",
+        "executedtime": "2024-03-15 19:00:00",
+        "jobticket": "1",
+        "ticketinfo": [
+          {
+            "bscompid": "768ba7fe80cd4360bbb5",
+            "bscompname": "bscom15",
+            "uploadid": "747e019131284bd3a020",
+            "currentversion": "",
+            "upgradeversion": "1.0",
+            "installlog": [
+              {
+                "Download": "2024-03-20 16:01:33.782459 Download Success 768ba7fe80cd4360bbb5",
+                "Install": "2024-03-20 16:02:03.888820 Install Fail 768ba7fe80cd4360bbb5"
+              }
+            ]
+          }
+        ],
+        "ticketresult": ""
+      },
+      {
+        "id": "3fadc30352144dc8a6d4",
+        "fieldid": "aa520ec8e5074f54b77d",
+        "fieldname": "ITRI2",
+        "tickettype": "2",
+        "ticketstatus": "3",
+        "executedtype": "1",
+        "executedtime": "2024-03-15 13:00:00",
+        "jobticket": "1",
+        "ticketinfo": [
+          {
+            "fieldId": "aa520ec8e5074f54b77d",
+            "start": "2024-03-14 00:00:00",
+            "end": "2024-03-14 23:59:59",
+            "iscustomized": 0
+          }
+        ],
+        "ticketresult": "PmReport-2024-03-20-16-01-04.xlsx"
+      },
+      {
+        "id": "7edf1bea0919445eb89d",
+        "fieldid": "aa520ec8e5074f54b77d",
+        "fieldname": "ITRI2",
+        "tickettype": "4",
+        "ticketstatus": "3",
+        "executedtype": "1",
+        "executedtime": "2024-03-15 10:00:00",
+        "jobticket": "1",
+        "ticketinfo": [
+          {
+            "fieldId": "aa520ec8e5074f54b77d",
+            "start": "2024-03-14 00:00:00",
+            "end": "2024-03-14 23:59:59"
+          }
+        ],
+        "ticketresult": "SwmReport-2024-03-20-16-01-29.xlsx"
+      },
+      {
+        "id": "f7259488c98645bebf7e",
+        "fieldid": "aa520ec8e5074f54b77d",
+        "fieldname": "ITRI2",
+        "tickettype": "3",
+        "ticketstatus": "3",
+        "executedtype": "0",
+        "executedtime": "2024-03-15 10:00:00",
+        "jobticket": "1",
+        "ticketinfo": [
+          {
+            "fieldId": "aa520ec8e5074f54b77d",
+            "start": "2024-03-01 00:00:00",
+            "end": "2024-03-14 15:00:00"
+          }
+        ],
+        "ticketresult": "FM_Report_2024-03-01-00-00-00-2024-03-14-15-00-00.xlsx"
+      },
+      {
+        "id": "6fd8e7652a7c4cd6a47e",
+        "fieldid": "aa520ec8e5074f54b77d",
+        "fieldname": "ITRI2",
+        "tickettype": "1",
+        "ticketstatus": "4",
+        "executedtype": "0",
+        "executedtime": "2024-03-15 09:35:00",
+        "jobticket": "1",
+        "ticketinfo": {
+          "fieldsnapshotid": "170bf2b11b794827b820",
+          "fieldsnapshotname": "123132"
+        },
+        "ticketresult": ""
+      }
+    ];
 
  }

--- a/src/app/shared/local-files/Schedule/For_queryJobTicketList.ts
+++ b/src/app/shared/local-files/Schedule/For_queryJobTicketList.ts
@@ -2,73 +2,255 @@
  // Interfaces of ScheduleList @2024/03/15 Add
  import { ScheduleList } from './../../interfaces/Schedule/For_queryJobTicketList';                       
 
- // Local Files for general ScheduleList @2024/03/15 Add
+ // Local Files for general ScheduleList @2024/03/21 Update
  export class localScheduleList {
 
     // For getQueryJobTicketList() Get local queryJobTicketList
     scheduleList_local: ScheduleList = {
+      
         "jobticket": [
+          {
+            "id": "59d1af12c92344259217",
+            "fieldid": "aa520ec8e5074f54b77d",
+            "tickettype": "1",
+            "ticketstatus": "0",
+            "executedtype": "3",
+            "executedtime": "2024-04-03 05:00:00",
+            "jobticket": "0",
+            "ticketresult": ""
+          },
+          {
+            "id": "7d9834a134bd473faf62",
+            "fieldid": "aa520ec8e5074f54b77d",
+            "tickettype": "4",
+            "ticketstatus": "0",
+            "executedtype": "2",
+            "executedtime": "2024-03-27 05:00:00",
+            "jobticket": "0",
+            "ticketresult": ""
+          },
+          {
+            "id": "3f69e61845f948fca0c8",
+            "fieldid": "aa520ec8e5074f54b77d",
+            "tickettype": "2",
+            "ticketstatus": "0",
+            "executedtype": "1",
+            "executedtime": "2024-03-22 13:00:00",
+            "jobticket": "0",
+            "ticketresult": ""
+          },
+          {
+            "id": "0a43733eeada462090bc",
+            "fieldid": "aa520ec8e5074f54b77d",
+            "tickettype": "4",
+            "ticketstatus": "0",
+            "executedtype": "1",
+            "executedtime": "2024-03-22 10:00:00",
+            "jobticket": "0",
+            "ticketresult": ""
+          },
+          {
+            "id": "dd9f0d4919164f8d90d8",
+            "fieldid": "aa520ec8e5074f54b77d",
+            "tickettype": "3",
+            "ticketstatus": "3",
+            "executedtype": "0",
+            "executedtime": "2024-03-21 14:00:00",
+            "jobticket": "1",
+            "ticketresult": "FM_Report_2024-03-01-00-00-00-2024-03-08-00-00-00.xlsx"
+          },
+          {
+            "id": "b771d42a70df4c6ab247",
+            "fieldid": "e6700d701f8b41f8950e",
+            "tickettype": "0",
+            "ticketstatus": "5",
+            "executedtype": "0",
+            "executedtime": "2024-03-21 13:14:00",
+            "jobticket": "1",
+            "ticketresult": ""
+          },
+          {
+            "id": "d1a274f2a2e44507ba61",
+            "fieldid": "aa520ec8e5074f54b77d",
+            "tickettype": "2",
+            "ticketstatus": "3",
+            "executedtype": "0",
+            "executedtime": "2024-03-21 13:11:00",
+            "jobticket": "1",
+            "ticketresult": "PmReportCustomized-2024-03-21-13-12-19.xlsx"
+          },
+          {
+            "id": "86c1dc7773224f60a040",
+            "fieldid": "aa520ec8e5074f54b77d",
+            "tickettype": "2",
+            "ticketstatus": "3",
+            "executedtype": "1",
+            "executedtime": "2024-03-21 13:00:00",
+            "jobticket": "1",
+            "ticketresult": "PmReport-2024-03-21-13-00-22.xlsx"
+          },
+          {
+            "id": "857118441dbf4255a5a2",
+            "fieldid": "aa520ec8e5074f54b77d",
+            "tickettype": "4",
+            "ticketstatus": "4",
+            "executedtype": "1",
+            "executedtime": "2024-03-21 10:00:00",
+            "jobticket": "1",
+            "ticketresult": ""
+          },
+          {
+            "id": "072978190052488e8ed7",
+            "fieldid": "aa520ec8e5074f54b77d",
+            "tickettype": "2",
+            "ticketstatus": "3",
+            "executedtype": "1",
+            "executedtime": "2024-03-20 13:00:00",
+            "jobticket": "1",
+            "ticketresult": "PmReport-2024-03-20-16-51-23.xlsx"
+          },
+          {
+            "id": "3d01156b231f405ab69a",
+            "fieldid": "aa520ec8e5074f54b77d",
+            "tickettype": "4",
+            "ticketstatus": "3",
+            "executedtype": "1",
+            "executedtime": "2024-03-20 10:00:00",
+            "jobticket": "1",
+            "ticketresult": "SwmReport-2024-03-20-16-51-46.xlsx"
+          },
+          {
+            "id": "b96b98b1a16344de9cfe",
+            "fieldid": "aa520ec8e5074f54b77d",
+            "tickettype": "2",
+            "ticketstatus": "3",
+            "executedtype": "1",
+            "executedtime": "2024-03-19 13:00:00",
+            "jobticket": "1",
+            "ticketresult": "PmReport-2024-03-20-16-50-24.xlsx"
+          },
+          {
+            "id": "e5e9a7817e4545c8b24b",
+            "fieldid": "aa520ec8e5074f54b77d",
+            "tickettype": "4",
+            "ticketstatus": "3",
+            "executedtype": "1",
+            "executedtime": "2024-03-19 10:00:00",
+            "jobticket": "1",
+            "ticketresult": "SwmReport-2024-03-20-16-50-50.xlsx"
+          },
+          {
+            "id": "8e984caa71ce497b8600",
+            "fieldid": "aa520ec8e5074f54b77d",
+            "tickettype": "2",
+            "ticketstatus": "3",
+            "executedtype": "1",
+            "executedtime": "2024-03-18 13:00:00",
+            "jobticket": "1",
+            "ticketresult": "PmReport-2024-03-20-16-49-29.xlsx"
+          },
+          {
+            "id": "2861ef7ef2a24982ae00",
+            "fieldid": "aa520ec8e5074f54b77d",
+            "tickettype": "4",
+            "ticketstatus": "3",
+            "executedtype": "1",
+            "executedtime": "2024-03-18 10:00:00",
+            "jobticket": "1",
+            "ticketresult": "SwmReport-2024-03-20-16-49-26.xlsx"
+          },
+          {
+            "id": "ce430c58566d40aca51b",
+            "fieldid": "aa520ec8e5074f54b77d",
+            "tickettype": "2",
+            "ticketstatus": "3",
+            "executedtype": "1",
+            "executedtime": "2024-03-17 13:00:00",
+            "jobticket": "1",
+            "ticketresult": "PmReport-2024-03-20-16-48-32.xlsx"
+          },
+          {
+            "id": "80d7bdf88585460b9967",
+            "fieldid": "aa520ec8e5074f54b77d",
+            "tickettype": "4",
+            "ticketstatus": "3",
+            "executedtype": "1",
+            "executedtime": "2024-03-17 10:00:00",
+            "jobticket": "1",
+            "ticketresult": "SwmReport-2024-03-20-16-48-23.xlsx"
+          },
+          {
+            "id": "13bd97bb48b14c4ebca1",
+            "fieldid": "aa520ec8e5074f54b77d",
+            "tickettype": "2",
+            "ticketstatus": "3",
+            "executedtype": "1",
+            "executedtime": "2024-03-16 13:00:00",
+            "jobticket": "1",
+            "ticketresult": "PmReport-2024-03-20-16-47-24.xlsx"
+          },
+          {
+            "id": "d7ff5b400f57488788e1",
+            "fieldid": "aa520ec8e5074f54b77d",
+            "tickettype": "4",
+            "ticketstatus": "3",
+            "executedtype": "1",
+            "executedtime": "2024-03-16 10:00:00",
+            "jobticket": "1",
+            "ticketresult": "SwmReport-2024-03-20-16-47-49.xlsx"
+          },
           {
             "id": "9e75da718d3a4739b517",
             "fieldid": "aa520ec8e5074f54b77d",
             "tickettype": "0",
-            "ticketstatus": "0",
+            "ticketstatus": "5",
             "executedtype": "0",
-            "executedtime": "2024-03-09 19:00:00",
-            "jobticket": "0",
+            "executedtime": "2024-03-15 19:00:00",
+            "jobticket": "1",
             "ticketresult": ""
           },
           {
             "id": "3fadc30352144dc8a6d4",
             "fieldid": "aa520ec8e5074f54b77d",
             "tickettype": "2",
-            "ticketstatus": "1",
+            "ticketstatus": "3",
             "executedtype": "1",
-            "executedtime": "2024-03-16 13:00:00",
-            "jobticket": "0",
-            "ticketresult": ""
+            "executedtime": "2024-03-15 13:00:00",
+            "jobticket": "1",
+            "ticketresult": "PmReport-2024-03-20-16-01-04.xlsx"
           },
           {
             "id": "7edf1bea0919445eb89d",
             "fieldid": "aa520ec8e5074f54b77d",
             "tickettype": "4",
-            "ticketstatus": "2",
+            "ticketstatus": "3",
             "executedtype": "1",
-            "executedtime": "2024-03-14 10:00:00",
-            "jobticket": "0",
-            "ticketresult": ""
+            "executedtime": "2024-03-15 10:00:00",
+            "jobticket": "1",
+            "ticketresult": "SwmReport-2024-03-20-16-01-29.xlsx"
           },
           {
             "id": "f7259488c98645bebf7e",
             "fieldid": "aa520ec8e5074f54b77d",
             "tickettype": "3",
-            "ticketstatus": "1",
+            "ticketstatus": "3",
             "executedtype": "0",
             "executedtime": "2024-03-15 10:00:00",
-            "jobticket": "0",
-            "ticketresult": ""
+            "jobticket": "1",
+            "ticketresult": "FM_Report_2024-03-01-00-00-00-2024-03-14-15-00-00.xlsx"
           },
           {
             "id": "6fd8e7652a7c4cd6a47e",
             "fieldid": "aa520ec8e5074f54b77d",
             "tickettype": "1",
-            "ticketstatus": "0",
+            "ticketstatus": "4",
             "executedtype": "0",
-            "executedtime": "2024-03-11 09:35:00",
-            "jobticket": "0",
-            "ticketresult": ""
-          },
-          {
-            "id": "af0c1fc4c90b4205a3ca",
-            "fieldid": "f769da087f2044e7a0d7",
-            "tickettype": "2",
-            "ticketstatus": "2",
-            "executedtype": "0",
-            "executedtime": "2024-03-13 11:40:00",
-            "jobticket": "0",
+            "executedtime": "2024-03-15 09:35:00",
+            "jobticket": "1",
             "ticketresult": ""
           }
         ]
       }
+      
 
 }

--- a/src/app/shared/service/language.service.ts
+++ b/src/app/shared/service/language.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@angular/core';
+// LanguageService
+import { EventEmitter, Injectable, Output } from '@angular/core';
 import { Enlanguage } from '../language-models/en-language';
 import { TwLanguage } from '../language-models/tw-language';
 
@@ -6,6 +7,9 @@ import { TwLanguage } from '../language-models/tw-language';
   providedIn: 'root'
 })
 export class LanguageService {
+
+  @Output() languageChanged = new EventEmitter<string>();
+  
   language = 'TW';   // 'EN' | 'TW'
   i18n: any = {};
 
@@ -43,9 +47,11 @@ export class LanguageService {
      this.updateBodyLanguageClass(this.language); // @2024/01/26 Add
   }
 
+  // @2024/03/21 Add
   changeI18n( language: string ) {
     this.language = language;
     this.setLanguage();
+    this.languageChanged.emit( language );
   }
 
   toggleChange() {


### PR DESCRIPTION
1. 調整 BS, schedule 用 interface。
2. 調整 BS, schedule 用 local files。
3. 兩頁面加入顯示  Progress Spinner 機制。
4. 新增判定顯示 BS cell 數之機制。
5. 新增判定顯示 schedule 狀態之機制
6. 新增中英語言檔案所需之對應 schedule 狀態訊息。