### PR TITLE
BS、Schedule Mgmt 更新

### DIFF
--- a/src/app/bs-management/bs-info/bs-info.component.html
+++ b/src/app/bs-management/bs-info/bs-info.component.html
@@ -26,7 +26,7 @@
             </li>
             <li><!-- 基站Cell數量 -->
               <label>{{ languageService.i18n['BS.cellCount'] }}</label>
-              <span>{{ bsCellCount }}</span>
+              <span>{{ selectBsCellCount }}</span>
             </li>
             <li><!-- 基站地點說明 -->
               <label>{{ languageService.i18n['BS.description'] }}</label>

--- a/src/app/bs-management/bs-info/bs-info.component.ts
+++ b/src/app/bs-management/bs-info/bs-info.component.ts
@@ -89,8 +89,9 @@ export class BSInfoComponent implements OnInit {
   isLoadingBsInfo =  true;                            // 加載狀態的標誌，初始設置為 true
   selectBsInfo:      BSInfo = {} as BSInfo;           // 用於存儲從服務器或 Local Files 獲取的一體式基站資訊
   selectBsInfo_dist: BSInfo_dist = {} as BSInfo_dist; // 用於存儲從服務器或 Local Files 獲取的分佈式基站資訊
+  selectBsCellCount: number = 0;                      // 用於存儲當前選中的 BS Cell 數量
 
-  // @2024/03/25 Add
+  // @2024/03/26 Update
   // 用於獲取基站資訊
   getQueryBsInfo() {
     console.log( 'getQueryBsInfo() - Start' );
@@ -108,12 +109,20 @@ export class BSInfoComponent implements OnInit {
         this.selectBsInfo = this.bsInfo_LocalFiles.bsInfo_local.find( info => info.id === this.bsID ) || {} as BSInfo;
         console.log( 'In local - Get the BSInfo:', this.selectBsInfo );
 
+        // 一體式基站，直接將 Cell 數量設為 1
+        this.selectBsCellCount = 1;
+
       } else if ( this.bsType === "2" ) {
 
         // 取得 Local 分佈式基站資訊
         this.selectBsInfo_dist = this.bsInfo_LocalFiles.dist_bsInfo_local.find( info => info.id === this.bsID ) || {} as BSInfo_dist;
         console.log( 'In local - Get the BSInfo_dist:', this.selectBsInfo_dist );
+
+         // 對於分佈式基站，計算 RU 的數量 ( 透過 info 內資料筆數直接計算，因基本上每筆都會有一個 RU )
+         this.selectBsCellCount = this.selectBsInfo_dist.info.length; // 每個 RU 代表一個 Cell
       }
+
+      console.log(`In local - BS Type ${ this.bsType } - Cell Count: ${ this.bsCellCount }`);
 
       this.isLoadingBsInfo = false; // Local 模式下，數據加載快速完成,直接設置為 false
 
@@ -131,12 +140,20 @@ export class BSInfoComponent implements OnInit {
             this.selectBsInfo = res as BSInfo;
             console.log( 'Get the BSInfo:', this.selectBsInfo );
 
+            // 一體式基站，直接將 Cell 數量設為 1
+            this.selectBsCellCount = 1;
+
           } else if ( res.bstype === 2 ) {
 
             // 刷新分佈式基站資訊
             this.selectBsInfo_dist = res as BSInfo_dist; 
             console.log( 'Get the BSInfo_dist:', this.selectBsInfo_dist );
+
+            // 對於分佈式基站，計算 RU 的數量 ( 透過 info 內資料筆數直接計算，因基本上每筆都會有一個 RU )
+            this.selectBsCellCount = this.selectBsInfo_dist.info.length; // 每個 RU 代表一個 Cell
           }
+
+          console.log(`BS Type ${ this.bsType } - Cell Count: ${ this.bsCellCount }`);
 
           this.isLoadingBsInfo = false; // 數據加載完成
         },
@@ -152,8 +169,6 @@ export class BSInfoComponent implements OnInit {
 
     console.log( 'getQueryBsInfo() - End' );
   }
-
-
 
 
 

--- a/src/app/bs-management/bs-management.component.ts
+++ b/src/app/bs-management/bs-management.component.ts
@@ -217,7 +217,7 @@ export class BSManagementComponent implements OnInit {
       } else {
         console.log( `page[${this.p}] ===> no refresh.` );
       }
-    }, 10000 ); // 設定 10000 ms 後執行
+    }, 60000 ); // 設定 60000 ms ( 60s ) 後執行
   }
 
   selectBS!: Basestation;  // 用於存儲當前選中的 BS 訊息 @2024/03/22 Add

--- a/src/app/schedule-management/schedule-info/schedule-info.component.html
+++ b/src/app/schedule-management/schedule-info/schedule-info.component.html
@@ -1,5 +1,5 @@
-<!-- 使用 [ngClass] 根據條件動態添加 CSS -->
-<div class="ocloudInfo software" [ngClass]="{'kpiTable': shouldApplyKpiTableStyle()}">
+                                  <!-- 使用 [ngClass] 根據條件動態添加 CSS -->
+<div class="ocloudInfo software" [ngClass]="getDynamicClasses( selectScheduleInfo )">
   <h5>
     <button (click)="back()">
       <span class="material-icons">arrow_back</span>Back

--- a/src/app/schedule-management/schedule-info/schedule-info.component.ts
+++ b/src/app/schedule-management/schedule-info/schedule-info.component.ts
@@ -129,6 +129,9 @@ export class ScheduleInfoComponent implements OnInit {
       });
     }
   }
+
+
+
   
   // @2024/03/24 Add
   // isSfUpdateInfoArray 是一個自定義的類型守衛函數，用於檢查 `ticketinfo` 是否為 `sfUpdateInfo[]` 類型的陣列。
@@ -175,24 +178,44 @@ export class ScheduleInfoComponent implements OnInit {
     return customizedkpi ? Object.values( customizedkpi ) : [];
   }
 
-  // @2024/03/26 Add
-  // 在組件類中定義方法，用於檢查是否應該應用 'kpiTable' 樣式
-  shouldApplyKpiTableStyle(): boolean {
-    // 使用類型守衛函數 isPmReportInfoArray 來檢查 ticketinfo 是否是 pmReportInfo[] 類型
-    if (this.isPmReportInfoArray(this.selectScheduleInfo.ticketinfo)) {
-      // 如果是 pmReportInfo[] 類型，並且第一個元素的 iscustomized 屬性為 1，則返回 true
-      return this.selectScheduleInfo.ticketinfo[0].iscustomized === 1;
-    }
-    // 如果不是 pmReportInfo[] 類型或者 iscustomized 不為 1，則返回 false
-    return false;
-  }
-
   // @2024/03/24 Add
   // 檢查 ticketinfo 是否為 sfOrfmReportInfo[] 類型（當 tickettype 為 '3' 或 '4' 時）
   isSfOrfmReportInfoArray( ticketinfo: ScheduleInfo['ticketinfo'] ): ticketinfo is sfOrfmReportInfo[] {
     return ( this.selectScheduleInfo.tickettype === '3' || this.selectScheduleInfo.tickettype === '4' ) && Array.isArray( ticketinfo );
   }
 
+  // @2024/03/26 Add
+  // 在組件類中定義方法，根據不同條件返回對應的 CSS 類名
+  getDynamicClasses( scheduleInfo: ScheduleInfo ): Record<string, boolean> {
+    // 定義所有可能的 CSS 類名
+    const cssClasses: Record<string, boolean> = {
+      'sfUpdate': scheduleInfo.tickettype === '0',
+      'caReport': scheduleInfo.tickettype === '1',
+      'pmReport': scheduleInfo.tickettype === '2',
+      'fmReport': scheduleInfo.tickettype === '3',
+      'sfReport': scheduleInfo.tickettype === '4',
+    };
+  
+    // 檢查是否應該應用 kpiTable 樣式
+    cssClasses['kpiTable'] = this.shouldApplyKpiTableStyle(); // 無需if檢查，直接賦值
+  
+    return cssClasses;
+  }
+  
+  // @2024/03/26 Add
+  // 在組件類中定義方法，用於檢查是否應該應用 'kpiTable' 樣式
+  shouldApplyKpiTableStyle(): boolean {
+    
+    // 使用類型守衛函數 isPmReportInfoArray 來檢查 ticketinfo 是否是 pmReportInfo[] 類型
+    if ( this.isPmReportInfoArray( this.selectScheduleInfo.ticketinfo ) ) {
+
+      // 如果是 pmReportInfo[] 類型，並且第一個元素的 iscustomized 屬性為 1，則返回 true
+      return this.selectScheduleInfo.ticketinfo[0].iscustomized === 1;
+    }
+
+    // 如果不是 pmReportInfo[] 類型或者 iscustomized 不為 1，則返回 false
+    return false;
+  }
 
 
   // ↓ 控制顯示排程狀態的 icon 與訊息 @2024/03/22 Add ↓

--- a/src/app/schedule-management/schedule-management.component.ts
+++ b/src/app/schedule-management/schedule-management.component.ts
@@ -117,6 +117,7 @@ export class ScheduleManagementComponent implements OnInit {
 
     if ( this.commonService.isLocal ) {
       // Local 模式: 使用 Local 文件提供的數據
+      
       this.scheduleList = this.scheduleList_LocalFiles.scheduleList_local;
       console.log( 'In local - Get the ScheduleList:', this.scheduleList );
 
@@ -166,7 +167,7 @@ export class ScheduleManagementComponent implements OnInit {
 
         console.log(`page[${ this.p }] ===> no refresh.`);
       }
-    }, 10000 ); // 設定 10000 ms 後執行
+    }, 60000 ); // 設定 60000 ms ( 60s ) 後執行
   }
 
 

--- a/src/app/shared/language-models/en-language.ts
+++ b/src/app/shared/language-models/en-language.ts
@@ -297,7 +297,7 @@ export const Enlanguage = {
   'modify_faultMsg_status':'Modify Fault Message Status',
   'confirm_modify':'Confirm to modify',
   'pending_error':'Pending', //Modify by Charles (Pending Error->Pending)
-  'resolved':'Ended', //Modify by Charles (Resolved->Ended)
+  'resolved':'Ended',         //Modify by Charles (Resolved->Ended)
   'no_results':'No results were found. Please verify your search terms and try again.',
 
   // Dashboard


### PR DESCRIPTION
1. 加入使用 [ngClass] 根據條件動態依據排程類型添加對應的CSS。
2. 更新 BS、Schedule Mgmt 主頁列表刷新時間為每 60 秒刷新。
3. BS Mgmt 資訊頁新增依據 getQueryBsInfo 取得的 selectBsInfo 或 selectBsInfo_dist 來進行 Cell 數量的計算。