### PR TITLE
Field Mgmt 資訊頁更新 - "場域優化"

### DIFF
--- a/src/app/field-management/field-info/field-info.component.html
+++ b/src/app/field-management/field-info/field-info.component.html
@@ -1261,6 +1261,14 @@
 				<h4 class="inline-block">
 					{{ languageService.i18n['field.optimizationResult'] }}
 				</h4>
+
+				<!-- 清除計算結果並重置設定參數按鈕 -->
+				<div class="buttons">
+					<button type="button" (click)="resetFieldOptimizationForm(); clear_calculateSON();">
+						{{ languageService.i18n['field.clearAndReset'] }}
+					</button>
+				</div>
+
 				<div class="tabs">
 					<mat-button-toggle-group name="fieldOptimizationResultType" [ngModelOptions]="{standalone: true}" [(ngModel)]="fieldOptimizationResultType" (change)="changefieldOptimizationResultType($event)">
 						<mat-button-toggle value="cco" >CCO</mat-button-toggle>
@@ -1268,6 +1276,7 @@
 						<mat-button-toggle value="pci" >PCI</mat-button-toggle>
 					</mat-button-toggle-group>
 				</div>
+		
 				<!-- CCO 結果 -->
 				<div class="Field_Infos" *ngIf=" fieldOptimizationResultType === 'cco' ">
 					
@@ -1510,7 +1519,7 @@
 						{{ languageService.i18n['field.applySON'] }}
 					</button>
 					<!-- 取消按鈕 -->
-					<button type="button" (click)="clear_calculateSON(); resetFieldOptimizationForm()" >
+					<button type="button" (click)="clear_calculateSON(); resetFieldOptimizationForm()" mat-dialog-close>
 						{{ languageService.i18n['field.cancelSON'] }}
 					</button>
 				</div>

--- a/src/app/field-management/field-info/field-info.component.html
+++ b/src/app/field-management/field-info/field-info.component.html
@@ -1382,9 +1382,9 @@
 							</label>
 
 							<div>
-								<h6>PCI confusions </h6>
+								<h6>PCI Collisions</h6>
 								<label>
-									<div>Uni-directional pair count=0, ratio=0%</div>
+									<div>Uni-directional pair count = {{ pci_collisionCount }}, ratio = {{ pci_collisionRatio }} %</div>
 									<div class="table">
 										<table>
 											<thead>
@@ -1414,7 +1414,7 @@
 								</label>
 								<span class="material-symbols-outlined after">east</span>
 								<label>
-									<div>Uni-directional pair count=2, ratio=16.7%</div>
+									<div>Uni-directional pair count = {{ pci_collisionCount }}, ratio = {{ pci_collisionRatio }} %</div>
 									<div class="table">
 										<table>
 											<thead>
@@ -1444,9 +1444,9 @@
 								</label>
 							</div>
 							<div>
-								<h6>PCI confusions </h6>
+								<h6>PCI Confusions</h6>
 								<label>
-								<div>Uni-directional pair count=0, ratio=0%</div>
+								<div>Uni-directional pair count = {{ pci_confusionCount }}, ratio = {{ pci_confusionRatio }} %</div>
 									<div class="table">
 										<table>
 											<thead>
@@ -1479,7 +1479,7 @@
 								</label>
 								<span class="material-symbols-outlined after">east</span>
 								<label>
-									<div>Uni-directional pair count=2, ratio=16.7%</div>
+									<div>Uni-directional pair count = {{ pci_confusionCount }}, ratio = {{ pci_confusionRatio }} %</div>
 									<div class="table">
 										<table>
 											<thead>

--- a/src/app/field-management/field-info/field-info.component.ts
+++ b/src/app/field-management/field-info/field-info.component.ts
@@ -3138,38 +3138,6 @@ export class FieldInfoComponent implements OnInit {
     });
   }
 
-  // @2024/04/08 Update
-  // 點擊 場域優化 視窗的 close 按鈕行為
-  resetFieldOptimizationForm() {
-
-    // 重置整個"場域優化參數"表單
-    this.fieldOptimizationForm.reset({
-      setSONParameters: {
-        cco: true, // 默認 CCO 勾選
-        anr: true, // 默認 ANR 勾選
-        pci: true, // 默認 PCI 勾選
-      },
-      ccoSetParameters: '',
-      ueSyncMinSINR: -7,
-      pciMax: 100,
-      pciMin: 160
-      // ... 設定其他欄位的默認值
-    });
-
-    this.calculationCategories = [];
-    this.calculationResults = [];
-
-    // 重置顯示設定區域的標誌
-    this.showCCOSettings = false;
-    this.showANRSettings = false;
-    this.showPCISettings = false;
-
-    // 如果需要，這裡可以關閉場域優化視窗
-    this.fieldOptimizationWindow_Ref.close();
-
-    console.log("已關閉場域優化視窗，fieldOptimizationForm 已重製");
-  }
-
   // 創建表單組，用於"場域優化設定" @2024/03/30 Add
   fieldOptimizationForm!: FormGroup;
 
@@ -3200,6 +3168,55 @@ export class FieldInfoComponent implements OnInit {
       })
 
     });
+  }
+
+  // @2024/04/09 Update
+  // 點擊 場域優化 視窗的"重置"與"取消"按鈕行為
+  resetFieldOptimizationForm() {
+
+    // 重置整個"場域優化參數"表單
+    // this.fieldOptimizationForm.reset({
+    //   setSONParameters: {
+    //     cco: true, // 默認 CCO 勾選
+    //     anr: true, // 默認 ANR 勾選
+    //     pci: true, // 默認 PCI 勾選
+    //   },
+    //   ccoSetParameters: '',
+    //   ueSyncMinSINR: -7,
+    //   pciMax: 100,
+    //   pciMin: 160
+    //   // ... 設定其他欄位的默認值
+    // });
+
+    // @2024/04/09 Add
+    // 重新取得系統內現有設定 
+    this.populateFieldOptimizationForm();
+
+    this.calculationCategories = [];
+    this.calculationResults = [];
+
+    // @2024/04/09 Add
+    // 清空存儲計算結果的變數
+    this.gnbsCco = [];
+    this.gnbsAnr = [];
+    this.gnbsPci = [];
+    this.pciCollisions = [];
+    this.pciConfusions = [];
+    this.pci_collisionCount = 0;
+    this.pci_collisionRatio = 0;
+    this.pci_confusionCount = 0;
+    this.pci_confusionRatio = 0;
+
+
+    // 重置顯示設定區域的標誌
+    // this.showCCOSettings = false;
+    // this.showANRSettings = false;
+    // this.showPCISettings = false;
+
+    // 如果需要，這裡可以關閉場域優化視窗
+    //this.fieldOptimizationWindow_Ref.close();
+
+    console.log("已重置 fieldOptimizationForm 表單回系統內現有設定");
   }
 
   showCCOSettings = false;  // 是否顯示 CCO 設定區域 @2024/03/30 Add
@@ -3289,10 +3306,9 @@ export class FieldInfoComponent implements OnInit {
    *  - 但考慮到需求,這種方式可以快速地實現所需的效果
    * */
   toggleOptimizationType() {
-    const optimizationTypeHeader = document.querySelector( '.field-optim-wrap h4' );
+    const optimizationTypeHeader = document.querySelector('.field-optim-wrap h4');
     optimizationTypeHeader?.classList.toggle('active');
   }
-
 
   // @2024/04/08 Add
   fieldOptimizationResultType: string = 'cco'; // 預設選擇顯示 "cco" 
@@ -3333,10 +3349,22 @@ export class FieldInfoComponent implements OnInit {
   }
 
 
-  // @2024/04/08 Update
+  // @2024/04/09 Update
   // 發送計算 SON 演算法函數 
   calculateSON_Submit() {
     console.log( "calculateSON_Submit() - Start" );
+
+    // @2024/04/09 Add
+    // 清空存儲計算結果的變數，確保計算結果是最新的
+    this.gnbsCco = [];
+    this.gnbsAnr = [];
+    this.gnbsPci = [];
+    this.pciCollisions = [];
+    this.pciConfusions = [];
+    this.pci_collisionCount = 0;
+    this.pci_collisionRatio = 0;
+    this.pci_confusionCount = 0;
+    this.pci_confusionRatio = 0;
 
     this.isClickCalculate = true;
     this.getQuerySonParameter_Loading = true; // 顯示 Loading Progress Spinner
@@ -3395,16 +3423,20 @@ export class FieldInfoComponent implements OnInit {
     const ccoSetParam = this.fieldOptimizationForm.get('setSONParameters.ccoSetParameters')?.value;
 
     // 根據用戶選擇的 CCO 參數設置相關值
-    if (ccoSetParam === 'maxCoverageRange') {
+    if ( ccoSetParam === 'maxCoverageRange' ) {
+
       submitData.ratioCoverage = '100';
       submitData.ratioAverageSINR = '0';
       submitData.ratioFairCapacity = '0';
       submitData.ratioMaxCapacity = '0';
-    } else if (ccoSetParam === 'ratioAverageSINR') {
+
+    } else if ( ccoSetParam === 'ratioAverageSINR' ) {
+      
       submitData.ratioAverageSINR = '100';
       submitData.ratioCoverage = '0';
       submitData.ratioFairCapacity = '0';
       submitData.ratioMaxCapacity = '0';
+
     }
 
 
@@ -3430,7 +3462,7 @@ export class FieldInfoComponent implements OnInit {
       this.processCalculationResponse( this.calculationResponse );
 
       // @04/08 Add
-      // 計算完成後自動縮合種類區
+      // 計算完成後自動縮合優化種類區
       this.toggleOptimizationType();
 
       this.getQuerySonParameter_Loading = false; // 計算完成後停止 Loading Progress Spinner
@@ -3451,7 +3483,7 @@ export class FieldInfoComponent implements OnInit {
           this.processCalculationResponse( this.calculationResponse );
 
           // @04/08 Add
-          // 計算完成後自動縮合種類區
+          // 計算完成後自動縮合優化種類區
           this.toggleOptimizationType();
 
           this.getQuerySonParameter_Loading = false; // 計算完成後停止 Loading Progress Spinner
@@ -3477,15 +3509,21 @@ export class FieldInfoComponent implements OnInit {
     console.log( "calculateSON_Submit() - End" );
   }
 
-  // 清楚計算結果 @2024/04/02 Add
+  // @2024/04/09 Update
+  // 清楚場域優化計算結果 
   clear_calculateSON() {
 
     this.isCcoClass = false;
     this.isAnrClass = false;
     this.isPciClass = false;
     this.isClickCalculate = false;
-  }
 
+    console.log("已清除場域優化計算結果");
+
+    // @04/09 Add
+    // 清除場域優化計算結果後自動展開優化種類區
+    this.toggleOptimizationType();
+  }
 
   // 宣告變數來儲存 CCO 結果
   gnbsCco: cco_CellIndividualResult[] = [];
@@ -3526,6 +3564,8 @@ export class FieldInfoComponent implements OnInit {
     // 將取得的回傳值轉換成輸出到控制台上 this.allSimplifiedBsInfo
     console.log( "In processCalculationResponse() - SON calculation:", calculationResponse );
     console.log( "In processCalculationResponse() - this.allSimplifiedBsInfo:", this.allSimplifiedBsInfo );
+
+    console.log( "gnbsCco: ", this.gnbsCco );
     
     // 從回傳值中取出 cco、anr、pci 的結果資料
     const tempCco = calculationResponse.cco;
@@ -3613,7 +3653,7 @@ export class FieldInfoComponent implements OnInit {
 
     // 處理 CCO 結果資料
     if ( tempCco !== undefined && tempCco.cellIndividualResult ) {
-      // 將 CCO 的個別小區結果加入到 gnbsCco 陣列中
+      // 將 CCO 的個別 Cell 結果加入到 gnbsCco 陣列中
       tempCco.cellIndividualResult.forEach(res => {
         this.gnbsCco.push(res);
       });

--- a/src/app/shared/language-models/en-language.ts
+++ b/src/app/shared/language-models/en-language.ts
@@ -213,6 +213,8 @@ export const Enlanguage = {
   'field.pciMax': 'Maximum PCI',
 
   'field.sonCalculate':'Calculate',
+  'field.clearAndReset': 'Clear and Reset',
+
 
   'field.calculationCategories': 'Calculation Categories',
   'field.calculationResults': 'Calculation Results',

--- a/src/app/shared/language-models/tw-language.ts
+++ b/src/app/shared/language-models/tw-language.ts
@@ -212,6 +212,8 @@ export const TwLanguage = {
   'field.pciMax': 'PCI 最大值',
 
   'field.sonCalculate':'計算',
+  'field.clearAndReset': '清除並重置',
+
 
   'field.calculationCategories': '計算類別',
 


### PR DESCRIPTION
1. 新增"清除計算結果並重置設定參數" 按鈕與其功能。
2. 調整兩個重置函數至能更完整重置表單與計算結果 - resetFieldOptimizationForm()、clear_calculateSON()。
3. calculateSON_Submit()計算優化函數，加入於一開始先清空存儲計算結果的變數。
4. 新增 1. 按鈕所需中英語言對應檔案。
5. PCI Collisions、PCI Confusions 將兩個對應的計數與比率正確接上對應的 ts 取值變數。