### PR TITLE
Field Mgmt 資訊頁更新 - 新增當 BS 的 'info' 數據缺失時的備選方案

### DIFF
--- a/src/app/shared/interfaces/BS/For_queryBsInfo_BS.ts
+++ b/src/app/shared/interfaces/BS/For_queryBsInfo_BS.ts
@@ -54,7 +54,7 @@ export interface BSInfo {
     nci: string;
   
     NRCellCU: NRCELLCU | null;
-    gNBCUFunction: GNBCUFunction | null;
+    gNBCUFunction: GNBCUFunction;
     peeParametersList_CU: PeeParametersListCU | null;
     vnfParametersList_CU: VnfParametersListCU | null;
   

--- a/src/app/shared/interfaces/BS/For_queryBsInfo_dist_BS.ts
+++ b/src/app/shared/interfaces/BS/For_queryBsInfo_dist_BS.ts
@@ -80,8 +80,8 @@ export interface BSInfo_dist {
     cellLocalId: string;
     nci: string;
   
-    gNBCUFunction: GNBCUFunction | null;
-    NRCellCU: NRCELLCU | null;
+    gNBCUFunction: GNBCUFunction;
+    NRCellCU: NRCELLCU;
     peeParametersList_CU: PeeParametersListCU | null;
     vnfParametersList_CU: VnfParametersListCU | null;
   
@@ -95,13 +95,13 @@ export interface BSInfo_dist {
     s_NSSAI_leafList_NRCellCU: SNSSAILeafListNRCellCU | null;
   
     gNBDUFunction: GNBDUFunction | null;
-    NRCellDU: NRCELLDU | null;
+    NRCellDU: NRCELLDU;
     peeParametersList_DU: PeeParametersListDU | null;
     vnfParametersList_DU: VnfParametersListDU | null;
   
     EP_F1C_DU: EPF1C_DU | null;
     EP_F1U_DU: EPF1U_DU | null;
-    NRSectorCarrier: NRSectorCarrier | null;
+    NRSectorCarrier: NRSectorCarrier;
   
     BWP: Bwp | null;
     peeParametersList_NRSector: PeeParametersListNRSector | null;


### PR DESCRIPTION
優化了 convertBsInfoToSimplifiedFormat 和 convertDistBsInfoToSimplifiedFormat 函數，處理當 'info' 非陣列或為空的情況。現在會默認使用 'extension_info' 數據，以確保創建一致的 SimplifiedBSInfo 對象。

SimplifiedBSInfo 的 interface 也新增可取得 BS 的 componentId 與 cellInfo 資訊。

Add fallback for BSInfo without 'info' data

Enhanced convertBsInfoToSimplifiedFormat and convertDistBsInfoToSimplifiedFormat to handle cases where 'info' is not an array or is empty. Now gracefully defaults to 'extension_info' data to ensure consistent SimplifiedBSInfo object creation.

Added retrieval of `componentId` and `cellInfo` for BS to interface of `SimplifiedBSInfo`.