### PR TITLE
Field Mgmt、BS Mgmt - 多處調整

### DIFF
--- a/src/app/bs-management/bs-info/bs-info.component.ts
+++ b/src/app/bs-management/bs-info/bs-info.component.ts
@@ -208,7 +208,7 @@ export class BSInfoComponent implements OnInit {
    selectBsPosition: string = "";                     // 用於存儲當前選中的一體式 BS 位置
   selectDistBsPosition: string = "";                  // 用於存儲當前選中的分佈式 BS 位置
   
-  // 用於獲取基站資訊 @2024/03/27 Update
+  // 用於獲取基站資訊 @2024/04/12 Update - 更新計算分佈式 Cell 數方式，改跟基站主頁方法相同
   getQueryBsInfo() {
     console.log( 'getQueryBsInfo() - Start' );
 
@@ -240,11 +240,24 @@ export class BSInfoComponent implements OnInit {
         console.log( 'In local - Get the BSInfo_dist:', this.selectBsInfo_dist );
         //console.log( 'In local - Get the BSInfo_dist position:', this.selectBsInfo_dist.position );
 
-         // 對於分佈式基站，計算 RU 的數量 ( 透過 info 內資料筆數直接計算，因基本上每筆都會有一個 RU )
-         this.selectBsCellCount = this.selectBsInfo_dist.info.length; // 每個 RU 代表一個 Cell
+        // 對於分佈式基站，計算 RU 的數量 ( 透過 info 內資料筆數直接計算，因基本上每筆都會有一個 RU )
+        //this.selectBsCellCount = this.selectBsInfo_dist.info.length; // 每個 RU 代表一個 Cell
+                   // 改用遍歷 components 計算 Cell 數量 @2024/04/12 Add
+        // 如果 bstype 為 2，需要遍歷 components 物件算 Cell 數量，每個 RU 代表一個 Cell
+        let cellCount = 0;
+        for ( const compKey in this.selectBsInfo_dist.components ) {
+          const compVal = this.selectBsInfo_dist.components[compKey];
+          for ( const innerKey in compVal ) {
+            // 取得內層陣列的長度，即 cell 數量
+            cellCount += compVal[innerKey].length;
+          }
+        }
+        // 使用 cellCount 設置 selectBsCellCount
+        this.selectBsCellCount = cellCount;
+
       }
 
-      console.log( `In local - BS Type ${ this.bsType } - Cell Count: ${ this.bsCellCount }` );
+      console.log( `In local - BS Type ${ this.bsType } - Cell Count: ${ this.selectBsCellCount }` );
 
       // @2024/03/27 Add
       // 取得基站資訊後，取得網元列表資訊並進行座標位置或軟體版本顯示資訊的相關處理 
@@ -282,10 +295,24 @@ export class BSInfoComponent implements OnInit {
             // console.log( 'Get the BSInfo_dist position:', this.selectDistBsPosition );
 
             // 對於分佈式基站，計算 RU 的數量 ( 透過 info 內資料筆數直接計算，因基本上每筆都會有一個 RU )
-            this.selectBsCellCount = this.selectBsInfo_dist.info.length; // 每個 RU 代表一個 Cell
+            //this.selectBsCellCount = this.selectBsInfo_dist.info.length; // 每個 RU 代表一個 Cell
+
+            // 改用遍歷 components 計算 Cell 數量 @2024/04/12 Add
+            // 如果 bstype 為 2，需要遍歷 components 物件算 Cell 數量，每個 RU 代表一個 Cell
+            let cellCount = 0;
+            for ( const compKey in this.selectBsInfo_dist.components ) {
+              const compVal = this.selectBsInfo_dist.components[compKey];
+              for ( const innerKey in compVal ) {
+                // 取得內層陣列的長度，即 cell 數量
+                cellCount += compVal[innerKey].length;
+              }
+            }
+            // 使用 cellCount 設置 selectBsCellCount
+            this.selectBsCellCount = cellCount;
+          
           }
           
-          console.log(`BS Type ${ this.bsType } - Cell Count: ${ this.bsCellCount }`);
+          console.log(`BS Type ${ this.bsType } - Cell Count: ${ this.selectBsCellCount }`);
 
           // @2024/03/27 Add
           // 取得基站資訊後，取得網元列表資訊並進行座標位置或軟體版本顯示資訊的相關處理 

--- a/src/app/field-management/field-info/field-info.component.ts
+++ b/src/app/field-management/field-info/field-info.component.ts
@@ -3313,7 +3313,7 @@ export class FieldInfoComponent implements OnInit {
   }
 
 
-  /** @2024/04/11 Update
+  /** @2024/04/12 Update
    *  點擊場域優化視窗的"清除並重置"與"取消"按鈕行為的函數
    *  @method resetFieldOptimizationForm
    *  @returns { void }
@@ -3365,6 +3365,8 @@ export class FieldInfoComponent implements OnInit {
 
     // 如果需要，這裡可以關閉場域優化視窗
     //this.fieldOptimizationWindow_Ref.close();
+
+    this.fieldOptimizationResultType = 'cco'; // 重置場域優化結果頁籤顯示類型為 CCO
 
     console.log("已重置 fieldOptimizationForm 表單回系統內現有設定");
   }
@@ -3678,7 +3680,7 @@ export class FieldInfoComponent implements OnInit {
     console.log( "calculateSON_Submit() - End" );
   }
 
-  /** @2024/04/09 Update
+  /** @2024/04/12 Update
    *  清除場域優化計算結果的函數
    *  @method clear_calculateSON
    *  @returns { void }
@@ -3697,6 +3699,8 @@ export class FieldInfoComponent implements OnInit {
     this.isClickCalculate = false;
 
     console.log("已清除場域優化計算結果");
+
+    this.fieldOptimizationResultType = 'cco'; // 重置場域優化結果頁籤顯示類型為 CCO
 
     // @04/09 Add
     // 清除場域優化計算結果後自動展開優化種類區

--- a/src/app/shared/interfaces/BS/For_queryBsInfo_dist_BS.ts
+++ b/src/app/shared/interfaces/BS/For_queryBsInfo_dist_BS.ts
@@ -1,26 +1,26 @@
 
-/* ↓ @12/24 Add For API of queryBsInfo for dist BS ↓ */
-// notes: 當物件有可能是空的或可能不在 JSON 中設為"?:"
-export interface BSInfo_dist {
-    info: Info_dist[];
-    extension_info: ExtensionInfo_dist[]; // ok
-    cellInfo: Cellinfo; // ok
-    anr: Anr;           // ok
-    pci: PCI;           // ok 目前沒看到有 BS 這個有值
-    cco: CCO;           // ok 目前沒看到有 BS 這個有值
-    id: string;         // ok
-    name: string;       // ok
-    ip: string;               // ok 不一定有值
-    port: string;             // ok 不一定有值
-    position: string;         // ok dist BS 有定義該參數但都沒有值
-    description: string;      // ok
-    bstype: number;           // ok
-    components: Components_dist;   // ok 可能會出錯
-    status: number;           // ok
-    laston: string;           // ok
-    lastoff: string | null;          // ok
-    'components-info': ComponentsInfo;   // ok 不一定有值
-}
+  /* ↓ @12/24 Add For API of queryBsInfo for dist BS ↓ */
+  // notes: 當物件有可能是空的或可能不在 JSON 中設為"?:"
+  export interface BSInfo_dist {
+      info: Info_dist[] | {};
+      extension_info: ExtensionInfo_dist[]; // ok
+      cellInfo: Cellinfo; // ok
+      anr: Anr;           // ok
+      pci: PCI;           // ok 目前沒看到有 BS 這個有值
+      cco: CCO;           // ok 目前沒看到有 BS 這個有值
+      id: string;         // ok
+      name: string;       // ok
+      ip: string;               // ok 不一定有值
+      port: string;             // ok 不一定有值
+      position: string;         // ok dist BS 有定義該參數但都沒有值
+      description: string;      // ok
+      bstype: number;           // ok
+      components: Components_dist;   // ok 可能會出錯
+      status: number;           // ok
+      laston: string;           // ok
+      lastoff: string | null;          // ok
+      'components-info': ComponentsInfo;   // ok 不一定有值
+  }
 
   /* ↓ @12/26 Add For info:[] ↓ */
 

--- a/src/app/shared/local-files/BS/For_queryBsInfo.ts
+++ b/src/app/shared/local-files/BS/For_queryBsInfo.ts
@@ -5,7 +5,7 @@
 
   // Local Files for general BS @12/27 Add by yuchen 
   export class localBSInfo {
-  
+  /*
     bsInfo_local: BSInfo[] = [
         {
             "info": {
@@ -10430,8 +10430,11480 @@
             }
           }
         }
-    ];
+    ];*/
 
+    bsInfo_local: BSInfo[] = [
+      {
+        "info": {
+          "bs-conf": {
+            "plmn-id": {
+              "mcc": "466",
+              "mnc": "55"
+            },
+            "nci": "000040108",
+            "pci": 153,
+            "nrarfcn-dl": 723333,
+            "nrarfcn-ul": 723333,
+            "duplex-mode": "",
+            "channel-bandwidth": 20,
+            "tac": "3000",
+            "tx-power": 4
+          },
+          "gNBId": 16,
+          "gNBIdLength": 22,
+          "gNB-type": "SA",
+          "gNBCUName": "cu1",
+          "pLMNId_MCC": "466",
+          "pLMNId_MNC": "55",
+          "id": "0"
+        },
+        "extension_info": [
+          {
+            "gNBId": 16,
+            "gNBIdLength": 22,
+            "cellLocalId": "100001000",
+            "nci": "000040108",
+            "NRCellCU": {
+              "db": {
+                "componentId": "2ec4af101a5b4eb4884a",
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              },
+              "ds": {
+                "componentId": "2ec4af101a5b4eb4884a",
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              }
+            },
+            "gNBCUFunction": {
+              "db": {
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "2ec4af101a5b4eb4884a",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "2ec4af101a5b4eb4884a",
+                "id": "0"
+              }
+            },
+            "peeParametersList_CU": {
+              "db": {
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_CU": {
+              "db": {
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_CU": {
+              "db": {
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_CU": {
+              "db": {
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              }
+            },
+            "EP_NgC": {
+              "db": {
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.5",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.5",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.5",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.5",
+                "id": "0"
+              }
+            },
+            "EP_NgU": {
+              "db": {
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.6",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.6",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.6",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.6",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellCU": {
+              "db": {
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "gNBDUFunction": {
+              "db": {
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "2ec4af101a5b4eb4884a",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "2ec4af101a5b4eb4884a",
+                "id": "0"
+              }
+            },
+            "NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 153,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "componentId": "2ec4af101a5b4eb4884a",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 100,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "id": "0",
+                "componentId": "2ec4af101a5b4eb4884a"
+              }
+            },
+            "peeParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrierRef_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              }
+            },
+            "bWPRef_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrier": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 4,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "bSChannelBwDL": 20,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 10,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 649788,
+                "arfcnUL": 649788,
+                "bSChannelBwDL": 100,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              }
+            },
+            "BWP": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 16,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRSector": null,
+            "vnfParametersList_NRSector": null,
+            "peeParametersList_BWP": null,
+            "vnfParametersList_BWP": null
+          }
+        ],
+        "cellInfo": {},
+        "anr": {
+          "anr-son-output": {
+            "neighbor": [
+              {
+                "id": "",
+                "nci": "00003c108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "0",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 160,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": "111111"
+              },
+              {
+                "id": "",
+                "nci": "000038108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "0",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 156,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": "111111"
+              }
+            ]
+          }
+        },
+        "pci": {},
+        "cco": {},
+        "id": "2b072e0d7f634ec5abce",
+        "name": "BS16",
+        "ip": "",
+        "port": "",
+        "position": "[121.045482,24.775000]",
+        "description": "BS16",
+        "bstype": 1,
+        "components": [
+          {
+            "type": "cu+du+ru",
+            "id": "2ec4af101a5b4eb4884a"
+          }
+        ],
+        "status": 2,
+        "laston": "2024-04-12 04:11:20.609559",
+        "lastoff": "2023-12-30 03:35:28.928799",
+        "components-info": {
+          "2ec4af101a5b4eb4884a": {
+            "firm": "ITRI",
+            "modelname": "A001",
+            "components-sw-inventory": {
+              "software-inventory": {
+                "software-slot": [
+                  {
+                    "name": "slot-1",
+                    "status": "VALID",
+                    "active": "true",
+                    "running": "true",
+                    "access": "READ_ONLY",
+                    "vendor-code": "K2",
+                    "build-id": "b01",
+                    "build-name": "product-default",
+                    "build-version": "0.1.0",
+                    "files": {
+                      "name": "file-1",
+                      "version": "0.2.3",
+                      "local-path": "~/some_dir/",
+                      "integrity": "OK"
+                    }
+                  },
+                  {
+                    "name": "slot-2",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-3",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-4",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      {
+        "info": {
+          "bs-conf": {
+            "plmn-id": {
+              "mcc": "466",
+              "mnc": "55"
+            },
+            "nci": "000018108",
+            "pci": 140,
+            "nrarfcn-dl": 723333,
+            "nrarfcn-ul": 723333,
+            "duplex-mode": "",
+            "channel-bandwidth": 20,
+            "tac": "3000",
+            "tx-power": 4
+          },
+          "gNBId": 6,
+          "gNBIdLength": 22,
+          "gNB-type": "SA",
+          "gNBCUName": "cu1",
+          "pLMNId_MCC": "466",
+          "pLMNId_MNC": "55",
+          "id": "0"
+        },
+        "extension_info": [
+          {
+            "gNBId": 6,
+            "gNBIdLength": 22,
+            "cellLocalId": "100001000",
+            "nci": "000018108",
+            "NRCellCU": {
+              "db": {
+                "componentId": "c10e99eb5faf440f9404",
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              },
+              "ds": {
+                "componentId": "c10e99eb5faf440f9404",
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              }
+            },
+            "gNBCUFunction": {
+              "db": {
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "c10e99eb5faf440f9404",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "c10e99eb5faf440f9404",
+                "id": "0"
+              }
+            },
+            "peeParametersList_CU": {
+              "db": {
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_CU": {
+              "db": {
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_CU": {
+              "db": {
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_CU": {
+              "db": {
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              }
+            },
+            "EP_NgC": {
+              "db": {
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.5",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.5",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.5",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.5",
+                "id": "0"
+              }
+            },
+            "EP_NgU": {
+              "db": {
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.6",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.6",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.6",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.6",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellCU": {
+              "db": {
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "gNBDUFunction": {
+              "db": {
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "c10e99eb5faf440f9404",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "c10e99eb5faf440f9404",
+                "id": "0"
+              }
+            },
+            "NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 140,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "componentId": "c10e99eb5faf440f9404",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 100,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "id": "0",
+                "componentId": "c10e99eb5faf440f9404"
+              }
+            },
+            "peeParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrierRef_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              }
+            },
+            "bWPRef_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrier": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 4,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "bSChannelBwDL": 20,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 10,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 649788,
+                "arfcnUL": 649788,
+                "bSChannelBwDL": 100,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              }
+            },
+            "BWP": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 6,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRSector": null,
+            "vnfParametersList_NRSector": null,
+            "peeParametersList_BWP": null,
+            "vnfParametersList_BWP": null
+          }
+        ],
+        "cellInfo": {},
+        "anr": {
+          "anr-son-output": {
+            "neighbor": [
+              {
+                "id": "",
+                "nci": "00001c108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 152,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000024001",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "66"
+                },
+                "nrarfcn": 4850,
+                "pci": 158,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000014108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 142,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000030108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 141,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000004108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 139,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000008108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 148,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000028108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 157,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000010108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 149,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000020108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 145,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "00000c108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 151,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              }
+            ]
+          }
+        },
+        "pci": {},
+        "cco": {},
+        "id": "31e8142a41f9411f8855",
+        "name": "BS6",
+        "ip": "",
+        "port": "",
+        "position": "[121.043187,24.776462]",
+        "description": "BS06",
+        "bstype": 1,
+        "components": [
+          {
+            "type": "cu+du+ru",
+            "id": "c10e99eb5faf440f9404"
+          }
+        ],
+        "status": 2,
+        "laston": "2024-04-12 04:11:20.750410",
+        "lastoff": "2024-01-02 11:45:26.836341",
+        "components-info": {
+          "c10e99eb5faf440f9404": {
+            "firm": "ITRI",
+            "modelname": "A001",
+            "components-sw-inventory": {
+              "software-inventory": {
+                "software-slot": [
+                  {
+                    "name": "slot-1",
+                    "status": "VALID",
+                    "active": "true",
+                    "running": "true",
+                    "access": "READ_ONLY",
+                    "vendor-code": "K2",
+                    "build-id": "b01",
+                    "build-name": "product-default",
+                    "build-version": "0.1.0",
+                    "files": {
+                      "name": "file-1",
+                      "version": "0.2.3",
+                      "local-path": "~/some_dir/",
+                      "integrity": "OK"
+                    }
+                  },
+                  {
+                    "name": "slot-2",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-3",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-4",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      {
+        "info": {
+          "bs-conf": {
+            "plmn-id": {
+              "mcc": "466",
+              "mnc": "55"
+            },
+            "nci": "00002c108",
+            "pci": 154,
+            "nrarfcn-dl": 723333,
+            "nrarfcn-ul": 3333,
+            "duplex-mode": "",
+            "channel-bandwidth": 20,
+            "tac": "3000",
+            "tx-power": 4
+          },
+          "gNBId": 11,
+          "gNBIdLength": 22,
+          "gNB-type": "SA",
+          "gNBCUName": "cu1",
+          "pLMNId_MCC": "466",
+          "pLMNId_MNC": "55",
+          "id": "0"
+        },
+        "extension_info": [
+          {
+            "gNBId": 11,
+            "gNBIdLength": 22,
+            "cellLocalId": "100001000",
+            "nci": "00002c108",
+            "NRCellCU": {
+              "db": {
+                "componentId": "4279c2e2d3e4422d9e71",
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              },
+              "ds": {
+                "componentId": "4279c2e2d3e4422d9e71",
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              }
+            },
+            "gNBCUFunction": {
+              "db": {
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "4279c2e2d3e4422d9e71",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "4279c2e2d3e4422d9e71",
+                "id": "0"
+              }
+            },
+            "peeParametersList_CU": {
+              "db": {
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_CU": {
+              "db": {
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_CU": {
+              "db": {
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_CU": {
+              "db": {
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              }
+            },
+            "EP_NgC": {
+              "db": {
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.5",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.5",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.5",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.5",
+                "id": "0"
+              }
+            },
+            "EP_NgU": {
+              "db": {
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.6",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.6",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.6",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.6",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellCU": {
+              "db": {
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "gNBDUFunction": {
+              "db": {
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "4279c2e2d3e4422d9e71",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "4279c2e2d3e4422d9e71",
+                "id": "0"
+              }
+            },
+            "NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 154,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 3333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "componentId": "4279c2e2d3e4422d9e71",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 100,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "id": "0",
+                "componentId": "4279c2e2d3e4422d9e71"
+              }
+            },
+            "peeParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrierRef_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              }
+            },
+            "bWPRef_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrier": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 4,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 723333,
+                "arfcnUL": 3333,
+                "bSChannelBwDL": 20,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 10,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 649788,
+                "arfcnUL": 649788,
+                "bSChannelBwDL": 100,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              }
+            },
+            "BWP": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRSector": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "idRef": "0",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.1111",
+                "siteLongitude": "10.2222",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "idRef": "0",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.1111",
+                "siteLongitude": "10.2222",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRSector": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "idRef": "0",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "idRef": "0",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "peeParametersList_BWP": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "idRef": "0",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.3333",
+                "siteLongitude": "10.4444",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "idRef": "0",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.3333",
+                "siteLongitude": "10.4444",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_BWP": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "idRef": "0",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 11,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "idRef": "0",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            }
+          }
+        ],
+        "cellInfo": {},
+        "anr": {
+          "anr-son-output": {
+            "neighbor": [
+              {
+                "id": "",
+                "nci": "00001c108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 152,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "00004c108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 146,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000040108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 153,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000048108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 100,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000024002",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "66"
+                },
+                "nrarfcn": 4850,
+                "pci": 159,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000024001",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "66"
+                },
+                "nrarfcn": 4850,
+                "pci": 158,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000024003",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "66"
+                },
+                "nrarfcn": 4850,
+                "pci": 137,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000024004",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "66"
+                },
+                "nrarfcn": 4850,
+                "pci": 155,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "00003c108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 160,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000014108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 142,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000038108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 156,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000030108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 141,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000044108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 143,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000028108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 157,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000034108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 144,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              }
+            ]
+          }
+        },
+        "pci": {},
+        "cco": {},
+        "id": "3242af6da6554fc28ce3",
+        "name": "BS11",
+        "ip": "",
+        "port": "",
+        "position": "[121.045601,24.774559]",
+        "description": "BS11",
+        "bstype": 1,
+        "components": [
+          {
+            "type": "cu+du+ru",
+            "id": "4279c2e2d3e4422d9e71"
+          }
+        ],
+        "status": 2,
+        "laston": "2024-04-12 04:11:20.813388",
+        "lastoff": "2023-12-29 20:53:31.456347",
+        "components-info": {
+          "4279c2e2d3e4422d9e71": {
+            "firm": "ITRI",
+            "modelname": "A001",
+            "components-sw-inventory": {
+              "software-inventory": {
+                "software-slot": [
+                  {
+                    "name": "slot-1",
+                    "status": "VALID",
+                    "active": "true",
+                    "running": "true",
+                    "access": "READ_ONLY",
+                    "vendor-code": "K2",
+                    "build-id": "b01",
+                    "build-name": "product-default",
+                    "build-version": "0.1.0",
+                    "files": {
+                      "name": "file-1",
+                      "version": "0.2.3",
+                      "local-path": "~/some_dir/",
+                      "integrity": "OK"
+                    }
+                  },
+                  {
+                    "name": "slot-2",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-3",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-4",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      {
+        "info": {
+          "bs-conf": {
+            "plmn-id": {
+              "mcc": "466",
+              "mnc": "55"
+            },
+            "nci": "00003c108",
+            "pci": 160,
+            "nrarfcn-dl": 723333,
+            "nrarfcn-ul": 723333,
+            "duplex-mode": "",
+            "channel-bandwidth": 20,
+            "tac": "3000",
+            "tx-power": 4
+          },
+          "gNBId": 15,
+          "gNBIdLength": 22,
+          "gNB-type": "SA",
+          "gNBCUName": "cu1",
+          "pLMNId_MCC": "466",
+          "pLMNId_MNC": "55",
+          "id": "0"
+        },
+        "extension_info": [
+          {
+            "gNBId": 15,
+            "gNBIdLength": 22,
+            "cellLocalId": "100001000",
+            "nci": "00003c108",
+            "NRCellCU": {
+              "db": {
+                "componentId": "768ba7fe80cd4360bbb5",
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              },
+              "ds": {
+                "componentId": "768ba7fe80cd4360bbb5",
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              }
+            },
+            "gNBCUFunction": {
+              "db": {
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "768ba7fe80cd4360bbb5",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "768ba7fe80cd4360bbb5",
+                "id": "0"
+              }
+            },
+            "peeParametersList_CU": {
+              "db": {
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_CU": {
+              "db": {
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_CU": {
+              "db": {
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_CU": {
+              "db": {
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              }
+            },
+            "EP_NgC": {
+              "db": {
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.5",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.5",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.5",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.5",
+                "id": "0"
+              }
+            },
+            "EP_NgU": {
+              "db": {
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.6",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.6",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.6",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.6",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellCU": {
+              "db": {
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "gNBDUFunction": {
+              "db": {
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "768ba7fe80cd4360bbb5",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "768ba7fe80cd4360bbb5",
+                "id": "0"
+              }
+            },
+            "NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 160,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "componentId": "768ba7fe80cd4360bbb5",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 100,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "id": "0",
+                "componentId": "768ba7fe80cd4360bbb5"
+              }
+            },
+            "peeParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrierRef_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              }
+            },
+            "bWPRef_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrier": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 4,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "bSChannelBwDL": 20,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 10,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 649788,
+                "arfcnUL": 649788,
+                "bSChannelBwDL": 100,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              }
+            },
+            "BWP": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 15,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRSector": null,
+            "vnfParametersList_NRSector": null,
+            "peeParametersList_BWP": null,
+            "vnfParametersList_BWP": null
+          }
+        ],
+        "cellInfo": {},
+        "anr": {
+          "anr-son-output": {
+            "neighbor": [
+              {
+                "id": "",
+                "nci": "000040108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "0",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 153,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": "111111"
+              },
+              {
+                "id": "",
+                "nci": "000038108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "0",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 156,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": "111111"
+              },
+              {
+                "id": "",
+                "nci": "000030108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "0",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 141,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": "111111"
+              },
+              {
+                "id": "",
+                "nci": "000034108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "0",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 144,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": "111111"
+              }
+            ]
+          }
+        },
+        "pci": {},
+        "cco": {},
+        "id": "6d1288b6ea8b4334af33",
+        "name": "BS15",
+        "ip": "",
+        "port": "",
+        "position": "[121.046958,24.773700]",
+        "description": "BS15",
+        "bstype": 1,
+        "components": [
+          {
+            "type": "cu+du+ru",
+            "id": "768ba7fe80cd4360bbb5"
+          }
+        ],
+        "status": 2,
+        "laston": "2024-04-12 21:44:56.392076",
+        "lastoff": "2023-12-27 16:15:07.202471",
+        "components-info": {
+          "768ba7fe80cd4360bbb5": {
+            "firm": "ITRI",
+            "modelname": "A001",
+            "components-sw-inventory": {
+              "software-inventory": {
+                "software-slot": [
+                  {
+                    "name": "slot-1",
+                    "status": "VALID",
+                    "active": "true",
+                    "running": "true",
+                    "access": "READ_ONLY",
+                    "vendor-code": "K2",
+                    "build-id": "b01",
+                    "build-name": "product-default",
+                    "build-version": "0.1.0",
+                    "files": {
+                      "name": "file-1",
+                      "version": "0.2.3",
+                      "local-path": "~/some_dir/",
+                      "integrity": "OK"
+                    }
+                  },
+                  {
+                    "name": "slot-2",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-3",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-4",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      {
+        "info": {
+          "bs-conf": {
+            "plmn-id": {
+              "mcc": "466",
+              "mnc": "55"
+            },
+            "nci": "000014108",
+            "pci": 142,
+            "nrarfcn-dl": 723333,
+            "nrarfcn-ul": 723333,
+            "duplex-mode": "",
+            "channel-bandwidth": 20,
+            "tac": "3000",
+            "tx-power": 4
+          },
+          "gNBId": 5,
+          "gNBIdLength": 22,
+          "gNB-type": "SA",
+          "gNBCUName": "cu1",
+          "pLMNId_MCC": "466",
+          "pLMNId_MNC": "55",
+          "id": "0"
+        },
+        "extension_info": [
+          {
+            "gNBId": 5,
+            "gNBIdLength": 22,
+            "cellLocalId": "100001000",
+            "nci": "000014108",
+            "NRCellCU": {
+              "db": {
+                "componentId": "b65db7a58227447e8045",
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              },
+              "ds": {
+                "componentId": "b65db7a58227447e8045",
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              }
+            },
+            "gNBCUFunction": {
+              "db": {
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "b65db7a58227447e8045",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "b65db7a58227447e8045",
+                "id": "0"
+              }
+            },
+            "peeParametersList_CU": {
+              "db": {
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_CU": {
+              "db": {
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_CU": {
+              "db": {
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_CU": {
+              "db": {
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              }
+            },
+            "EP_NgC": {
+              "db": {
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.5",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.5",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.5",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.5",
+                "id": "0"
+              }
+            },
+            "EP_NgU": {
+              "db": {
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.6",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.6",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.6",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.6",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellCU": {
+              "db": {
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "gNBDUFunction": {
+              "db": {
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "b65db7a58227447e8045",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "b65db7a58227447e8045",
+                "id": "0"
+              }
+            },
+            "NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 142,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "componentId": "b65db7a58227447e8045",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 100,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "id": "0",
+                "componentId": "b65db7a58227447e8045"
+              }
+            },
+            "peeParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrierRef_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              }
+            },
+            "bWPRef_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrier": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 4,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 649788,
+                "arfcnUL": 649788,
+                "bSChannelBwDL": 100,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 10,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 649788,
+                "arfcnUL": 649788,
+                "bSChannelBwDL": 100,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              }
+            },
+            "BWP": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 5,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRSector": null,
+            "vnfParametersList_NRSector": null,
+            "peeParametersList_BWP": null,
+            "vnfParametersList_BWP": null
+          }
+        ],
+        "cellInfo": {},
+        "anr": {
+          "anr-son-output": {
+            "neighbor": [
+              {
+                "id": "",
+                "nci": "00001c108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 152,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000018108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 140,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "00002c108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 154,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000024002",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "66"
+                },
+                "nrarfcn": 4850,
+                "pci": 159,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000024001",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "66"
+                },
+                "nrarfcn": 4850,
+                "pci": 158,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000024003",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "66"
+                },
+                "nrarfcn": 4850,
+                "pci": 137,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000030108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 141,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000004108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 139,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000008108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 148,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000028108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 157,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000010108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 149,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000020108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 145,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              }
+            ]
+          }
+        },
+        "pci": {},
+        "cco": {},
+        "id": "75acd33433a44dd6b8a5",
+        "name": "BS5",
+        "ip": "",
+        "port": "",
+        "position": "[121.042983,24.775178]",
+        "description": "BS05",
+        "bstype": 1,
+        "components": [
+          {
+            "type": "cu+du+ru",
+            "id": "b65db7a58227447e8045"
+          }
+        ],
+        "status": 2,
+        "laston": "2024-04-12 21:44:56.476899",
+        "lastoff": "2024-01-02 11:45:27.172762",
+        "components-info": {
+          "b65db7a58227447e8045": {
+            "firm": "ITRI",
+            "modelname": "A001",
+            "components-sw-inventory": {
+              "software-inventory": {
+                "software-slot": [
+                  {
+                    "name": "slot-1",
+                    "status": "VALID",
+                    "active": "true",
+                    "running": "true",
+                    "access": "READ_ONLY",
+                    "vendor-code": "K2",
+                    "build-id": "b01",
+                    "build-name": "product-default",
+                    "build-version": "0.1.0",
+                    "files": {
+                      "name": "file-1",
+                      "version": "0.2.3",
+                      "local-path": "~/some_dir/",
+                      "integrity": "OK"
+                    }
+                  },
+                  {
+                    "name": "slot-2",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-3",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-4",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      {
+        "info": {
+          "bs-conf": {
+            "plmn-id": {
+              "mcc": "466",
+              "mnc": "55"
+            },
+            "nci": "000038108",
+            "pci": 156,
+            "nrarfcn-dl": 723333,
+            "nrarfcn-ul": 723333,
+            "duplex-mode": "",
+            "channel-bandwidth": 20,
+            "tac": "3000",
+            "tx-power": 4
+          },
+          "gNBId": 14,
+          "gNBIdLength": 22,
+          "gNB-type": "SA",
+          "gNBCUName": "cu1",
+          "pLMNId_MCC": "466",
+          "pLMNId_MNC": "55",
+          "id": "0"
+        },
+        "extension_info": [
+          {
+            "gNBId": 14,
+            "gNBIdLength": 22,
+            "cellLocalId": "100001000",
+            "nci": "000038108",
+            "NRCellCU": {
+              "db": {
+                "componentId": "34022d76fefa4bb4a848",
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              },
+              "ds": {
+                "componentId": "34022d76fefa4bb4a848",
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              }
+            },
+            "gNBCUFunction": {
+              "db": {
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "34022d76fefa4bb4a848",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "34022d76fefa4bb4a848",
+                "id": "0"
+              }
+            },
+            "peeParametersList_CU": {
+              "db": {
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_CU": {
+              "db": {
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_CU": {
+              "db": {
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_CU": {
+              "db": {
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              }
+            },
+            "EP_NgC": {
+              "db": {
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.5",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.5",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.5",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.5",
+                "id": "0"
+              }
+            },
+            "EP_NgU": {
+              "db": {
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.6",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.6",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.6",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.6",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellCU": {
+              "db": {
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "gNBDUFunction": {
+              "db": {
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "34022d76fefa4bb4a848",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "34022d76fefa4bb4a848",
+                "id": "0"
+              }
+            },
+            "NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 156,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "componentId": "34022d76fefa4bb4a848",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 100,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "id": "0",
+                "componentId": "34022d76fefa4bb4a848"
+              }
+            },
+            "peeParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrierRef_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              }
+            },
+            "bWPRef_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrier": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 4,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "bSChannelBwDL": 20,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 10,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 649788,
+                "arfcnUL": 649788,
+                "bSChannelBwDL": 100,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              }
+            },
+            "BWP": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 14,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRSector": null,
+            "vnfParametersList_NRSector": null,
+            "peeParametersList_BWP": null,
+            "vnfParametersList_BWP": null
+          }
+        ],
+        "cellInfo": {},
+        "anr": {
+          "anr-son-output": {
+            "neighbor": [
+              {
+                "id": "",
+                "nci": "000040108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "0",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 153,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": "111111"
+              },
+              {
+                "id": "",
+                "nci": "00003c108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "0",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 160,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": "111111"
+              },
+              {
+                "id": "",
+                "nci": "000030108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "0",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 141,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": "111111"
+              },
+              {
+                "id": "",
+                "nci": "000034108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "0",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 144,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": "111111"
+              }
+            ]
+          }
+        },
+        "pci": {},
+        "cco": {},
+        "id": "7908a3e8cdf94229ac18",
+        "name": "BS14",
+        "ip": "",
+        "port": "",
+        "position": "[121.047552,24.774682]",
+        "description": "BS14",
+        "bstype": 1,
+        "components": [
+          {
+            "type": "cu+du+ru",
+            "id": "34022d76fefa4bb4a848"
+          }
+        ],
+        "status": 2,
+        "laston": "2024-04-12 21:44:56.536694",
+        "lastoff": "2023-12-30 09:20:17.453974",
+        "components-info": {
+          "34022d76fefa4bb4a848": {
+            "firm": "ITRI",
+            "modelname": "A001",
+            "components-sw-inventory": {
+              "software-inventory": {
+                "software-slot": [
+                  {
+                    "name": "slot-1",
+                    "status": "VALID",
+                    "active": "true",
+                    "running": "true",
+                    "access": "READ_ONLY",
+                    "vendor-code": "K2",
+                    "build-id": "b01",
+                    "build-name": "product-default",
+                    "build-version": "0.1.0",
+                    "files": {
+                      "name": "file-1",
+                      "version": "0.2.3",
+                      "local-path": "~/some_dir/",
+                      "integrity": "OK"
+                    }
+                  },
+                  {
+                    "name": "slot-2",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-3",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-4",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      {
+        "info": {
+          "bs-conf": {
+            "plmn-id": {
+              "mcc": "466",
+              "mnc": "55"
+            },
+            "nci": "000030108",
+            "pci": 141,
+            "nrarfcn-dl": 723333,
+            "nrarfcn-ul": 723333,
+            "duplex-mode": "",
+            "channel-bandwidth": 20,
+            "tac": "3000",
+            "tx-power": 4
+          },
+          "gNBId": 12,
+          "gNBIdLength": 22,
+          "gNB-type": "SA",
+          "gNBCUName": "cu1",
+          "pLMNId_MCC": "466",
+          "pLMNId_MNC": "55",
+          "id": "0"
+        },
+        "extension_info": [
+          {
+            "gNBId": 12,
+            "gNBIdLength": 22,
+            "cellLocalId": "100001000",
+            "nci": "000030108",
+            "NRCellCU": {
+              "db": {
+                "componentId": "77566db644d24af3b93f",
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              },
+              "ds": {
+                "componentId": "77566db644d24af3b93f",
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              }
+            },
+            "gNBCUFunction": {
+              "db": {
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "77566db644d24af3b93f",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "77566db644d24af3b93f",
+                "id": "0"
+              }
+            },
+            "peeParametersList_CU": {
+              "db": {
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_CU": {
+              "db": {
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_CU": {
+              "db": {
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_CU": {
+              "db": {
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              }
+            },
+            "EP_NgC": {
+              "db": {
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.5",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.5",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.5",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.5",
+                "id": "0"
+              }
+            },
+            "EP_NgU": {
+              "db": {
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.6",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.6",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.6",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.6",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellCU": {
+              "db": {
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "gNBDUFunction": {
+              "db": {
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "77566db644d24af3b93f",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "77566db644d24af3b93f",
+                "id": "0"
+              }
+            },
+            "NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 141,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "componentId": "77566db644d24af3b93f",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 100,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "id": "0",
+                "componentId": "77566db644d24af3b93f"
+              }
+            },
+            "peeParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrierRef_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              }
+            },
+            "bWPRef_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrier": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 4,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "bSChannelBwDL": 20,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 10,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 649788,
+                "arfcnUL": 649788,
+                "bSChannelBwDL": 100,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              }
+            },
+            "BWP": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 12,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRSector": null,
+            "vnfParametersList_NRSector": null,
+            "peeParametersList_BWP": null,
+            "vnfParametersList_BWP": null
+          }
+        ],
+        "cellInfo": {},
+        "anr": {
+          "anr-son-output": {
+            "neighbor": [
+              {
+                "id": "",
+                "nci": "00003c108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "0",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 160,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": "111111"
+              },
+              {
+                "id": "",
+                "nci": "000038108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "0",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 156,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": "111111"
+              },
+              {
+                "id": "",
+                "nci": "000044108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "0",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 143,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": "111111"
+              },
+              {
+                "id": "",
+                "nci": "000034108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "0",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 144,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": "111111"
+              }
+            ]
+          }
+        },
+        "pci": {},
+        "cco": {},
+        "id": "815c6f997c434114a3e5",
+        "name": "BS12",
+        "ip": "",
+        "port": "",
+        "position": "[121.045001,24.776136]",
+        "description": "BS12",
+        "bstype": 1,
+        "components": [
+          {
+            "type": "cu+du+ru",
+            "id": "77566db644d24af3b93f"
+          }
+        ],
+        "status": 2,
+        "laston": "2024-04-12 21:44:56.666274",
+        "lastoff": "2023-12-30 09:44:10.008023",
+        "components-info": {
+          "77566db644d24af3b93f": {
+            "firm": "ITRI",
+            "modelname": "A001",
+            "components-sw-inventory": {
+              "software-inventory": {
+                "software-slot": [
+                  {
+                    "name": "slot-1",
+                    "status": "VALID",
+                    "active": "true",
+                    "running": "true",
+                    "access": "READ_ONLY",
+                    "vendor-code": "K2",
+                    "build-id": "b01",
+                    "build-name": "product-default",
+                    "build-version": "0.1.0",
+                    "files": {
+                      "name": "file-1",
+                      "version": "0.2.3",
+                      "local-path": "~/some_dir/",
+                      "integrity": "OK"
+                    }
+                  },
+                  {
+                    "name": "slot-2",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-3",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-4",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      {
+        "info": {
+          "bs-conf": {
+            "plmn-id": {
+              "mcc": "466",
+              "mnc": "55"
+            },
+            "nci": "000004108",
+            "pci": 139,
+            "nrarfcn-dl": 723333,
+            "nrarfcn-ul": 723333,
+            "duplex-mode": "",
+            "channel-bandwidth": 20,
+            "tac": "3000",
+            "tx-power": 4
+          },
+          "gNBId": 1,
+          "gNBIdLength": 22,
+          "gNB-type": "SA",
+          "gNBCUName": "cu1",
+          "pLMNId_MCC": "466",
+          "pLMNId_MNC": "55",
+          "id": "0"
+        },
+        "extension_info": [
+          {
+            "gNBId": 1,
+            "gNBIdLength": 22,
+            "cellLocalId": "100001000",
+            "nci": "000004108",
+            "NRCellCU": {
+              "db": {
+                "componentId": "af04b2ee83c14d34902c",
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              },
+              "ds": {
+                "componentId": "af04b2ee83c14d34902c",
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              }
+            },
+            "gNBCUFunction": {
+              "db": {
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "af04b2ee83c14d34902c",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "af04b2ee83c14d34902c",
+                "id": "0"
+              }
+            },
+            "peeParametersList_CU": {
+              "db": {
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_CU": {
+              "db": {
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_CU": {
+              "db": {
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_CU": {
+              "db": {
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              }
+            },
+            "EP_NgC": {
+              "db": {
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "192.168.120.42",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "192.168.120.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.5",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.5",
+                "id": "0"
+              }
+            },
+            "EP_NgU": {
+              "db": {
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "5.5.5.42",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "5.5.5.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.6",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.6",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellCU": {
+              "db": {
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "gNBDUFunction": {
+              "db": {
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "af04b2ee83c14d34902c",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "af04b2ee83c14d34902c",
+                "id": "0"
+              }
+            },
+            "NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 139,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "componentId": "af04b2ee83c14d34902c",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 100,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "id": "0",
+                "componentId": "af04b2ee83c14d34902c"
+              }
+            },
+            "peeParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrierRef_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              }
+            },
+            "bWPRef_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrier": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 4,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "bSChannelBwDL": 20,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 10,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 649788,
+                "arfcnUL": 649788,
+                "bSChannelBwDL": 100,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              }
+            },
+            "BWP": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 1,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRSector": null,
+            "vnfParametersList_NRSector": null,
+            "peeParametersList_BWP": null,
+            "vnfParametersList_BWP": null
+          }
+        ],
+        "cellInfo": {},
+        "anr": {
+          "anr-son-output": {
+            "neighbor": [
+              {
+                "id": "",
+                "nci": "000044108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "0",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 143,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": "111111"
+              }
+            ]
+          }
+        },
+        "pci": {},
+        "cco": {},
+        "id": "97a606c4994344e09d3b",
+        "name": "BS1",
+        "ip": "",
+        "port": "",
+        "position": "[121.041167,24.776393]",
+        "description": "BS01",
+        "bstype": 1,
+        "components": [
+          {
+            "type": "cu+du+ru",
+            "id": "af04b2ee83c14d34902c"
+          }
+        ],
+        "status": 2,
+        "laston": "2024-04-12 21:44:56.880843",
+        "lastoff": "2023-12-29 09:44:07.231825",
+        "components-info": {
+          "af04b2ee83c14d34902c": {
+            "firm": "ITRI",
+            "modelname": "A001",
+            "components-sw-inventory": {
+              "software-inventory": {
+                "software-slot": [
+                  {
+                    "name": "slot-1",
+                    "status": "VALID",
+                    "active": "true",
+                    "running": "true",
+                    "access": "READ_ONLY",
+                    "vendor-code": "K2",
+                    "build-id": "b01",
+                    "build-name": "product-default",
+                    "build-version": "0.1.0",
+                    "files": {
+                      "name": "file-1",
+                      "version": "0.2.3",
+                      "local-path": "~/some_dir/",
+                      "integrity": "OK"
+                    }
+                  },
+                  {
+                    "name": "slot-2",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-3",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-4",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      {
+        "info": {
+          "bs-conf": {
+            "plmn-id": {
+              "mcc": "466",
+              "mnc": "55"
+            },
+            "nci": "000044108",
+            "pci": 143,
+            "nrarfcn-dl": 723333,
+            "nrarfcn-ul": 723333,
+            "duplex-mode": "",
+            "channel-bandwidth": 20,
+            "tac": "3000",
+            "tx-power": 4
+          },
+          "gNBId": 17,
+          "gNBIdLength": 22,
+          "gNB-type": "SA",
+          "gNBCUName": "cu1",
+          "pLMNId_MCC": "466",
+          "pLMNId_MNC": "55",
+          "id": "0"
+        },
+        "extension_info": [
+          {
+            "gNBId": 17,
+            "gNBIdLength": 22,
+            "cellLocalId": "100001000",
+            "nci": "000044108",
+            "NRCellCU": {
+              "db": {
+                "componentId": "004d2e7160da4deda404",
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              },
+              "ds": {
+                "componentId": "004d2e7160da4deda404",
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              }
+            },
+            "gNBCUFunction": {
+              "db": {
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "004d2e7160da4deda404",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "004d2e7160da4deda404",
+                "id": "0"
+              }
+            },
+            "peeParametersList_CU": {
+              "db": {
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_CU": {
+              "db": {
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_CU": {
+              "db": {
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_CU": {
+              "db": {
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              }
+            },
+            "EP_NgC": {
+              "db": {
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.5",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.5",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.5",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.5",
+                "id": "0"
+              }
+            },
+            "EP_NgU": {
+              "db": {
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.6",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.6",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.6",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.6",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellCU": {
+              "db": {
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "gNBDUFunction": {
+              "db": {
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "004d2e7160da4deda404",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "004d2e7160da4deda404",
+                "id": "0"
+              }
+            },
+            "NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 143,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "componentId": "004d2e7160da4deda404",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 100,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "id": "0",
+                "componentId": "004d2e7160da4deda404"
+              }
+            },
+            "peeParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrierRef_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              }
+            },
+            "bWPRef_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrier": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 4,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "bSChannelBwDL": 20,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 10,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 649788,
+                "arfcnUL": 649788,
+                "bSChannelBwDL": 100,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              }
+            },
+            "BWP": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 17,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRSector": null,
+            "vnfParametersList_NRSector": null,
+            "peeParametersList_BWP": null,
+            "vnfParametersList_BWP": null
+          }
+        ],
+        "cellInfo": {},
+        "anr": {
+          "anr-son-output": {
+            "neighbor": [
+              {
+                "id": "",
+                "nci": "000030108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "0",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 141,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": "111111"
+              },
+              {
+                "id": "",
+                "nci": "000004108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "0",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 139,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": "111111"
+              }
+            ]
+          }
+        },
+        "pci": {},
+        "cco": {},
+        "id": "9a4df79e890c4820b329",
+        "name": "BS17",
+        "ip": "",
+        "port": "",
+        "position": "[121.042,24.776378]",
+        "description": "BS17",
+        "bstype": 1,
+        "components": [
+          {
+            "type": "cu+du+ru",
+            "id": "004d2e7160da4deda404"
+          }
+        ],
+        "status": 2,
+        "laston": "2024-04-12 21:44:56.950939",
+        "lastoff": "2023-12-29 07:33:19.879219",
+        "components-info": {
+          "004d2e7160da4deda404": {
+            "firm": "ITRI",
+            "modelname": "A001",
+            "components-sw-inventory": {
+              "software-inventory": {
+                "software-slot": [
+                  {
+                    "name": "slot-1",
+                    "status": "VALID",
+                    "active": "true",
+                    "running": "true",
+                    "access": "READ_ONLY",
+                    "vendor-code": "K2",
+                    "build-id": "b01",
+                    "build-name": "product-default",
+                    "build-version": "0.1.0",
+                    "files": {
+                      "name": "file-1",
+                      "version": "0.2.3",
+                      "local-path": "~/some_dir/",
+                      "integrity": "OK"
+                    }
+                  },
+                  {
+                    "name": "slot-2",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-3",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-4",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      {
+        "info": {
+          "bs-conf": {
+            "plmn-id": {
+              "mcc": "466",
+              "mnc": "55"
+            },
+            "nci": "000008108",
+            "pci": 148,
+            "nrarfcn-dl": 723333,
+            "nrarfcn-ul": 723333,
+            "duplex-mode": "",
+            "channel-bandwidth": 20,
+            "tac": "3000",
+            "tx-power": 4
+          },
+          "gNBId": 2,
+          "gNBIdLength": 22,
+          "gNB-type": "SA",
+          "gNBCUName": "cu1",
+          "pLMNId_MCC": "466",
+          "pLMNId_MNC": "55",
+          "id": "0"
+        },
+        "extension_info": [
+          {
+            "gNBId": 2,
+            "gNBIdLength": 22,
+            "cellLocalId": "100001000",
+            "nci": "000008108",
+            "NRCellCU": {
+              "db": {
+                "componentId": "a4d48045771c4ce09424",
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              },
+              "ds": {
+                "componentId": "a4d48045771c4ce09424",
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              }
+            },
+            "gNBCUFunction": {
+              "db": {
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "a4d48045771c4ce09424",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "a4d48045771c4ce09424",
+                "id": "0"
+              }
+            },
+            "peeParametersList_CU": {
+              "db": {
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_CU": {
+              "db": {
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_CU": {
+              "db": {
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_CU": {
+              "db": {
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              }
+            },
+            "EP_NgC": {
+              "db": {
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.5",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.5",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.5",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.5",
+                "id": "0"
+              }
+            },
+            "EP_NgU": {
+              "db": {
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.6",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.6",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.6",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.6",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellCU": {
+              "db": {
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "gNBDUFunction": {
+              "db": {
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "a4d48045771c4ce09424",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "a4d48045771c4ce09424",
+                "id": "0"
+              }
+            },
+            "NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 148,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "componentId": "a4d48045771c4ce09424",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 100,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "id": "0",
+                "componentId": "a4d48045771c4ce09424"
+              }
+            },
+            "peeParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrierRef_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              }
+            },
+            "bWPRef_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrier": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 4,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "bSChannelBwDL": 20,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 10,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 649788,
+                "arfcnUL": 649788,
+                "bSChannelBwDL": 100,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              }
+            },
+            "BWP": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 2,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRSector": null,
+            "vnfParametersList_NRSector": null,
+            "peeParametersList_BWP": null,
+            "vnfParametersList_BWP": null
+          }
+        ],
+        "cellInfo": {},
+        "anr": {
+          "anr-son-output": {
+            "neighbor": [
+              {
+                "id": "",
+                "nci": "00001c108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 152,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000018108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 140,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000014108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 142,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000004108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 139,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000010108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 149,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "00000c108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 151,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              }
+            ]
+          }
+        },
+        "pci": {},
+        "cco": {},
+        "id": "c62e5330bda64c51ad16",
+        "name": "BS2",
+        "ip": "",
+        "port": "",
+        "position": "[121.041934,24.777122]",
+        "description": "BS02",
+        "bstype": 1,
+        "components": [
+          {
+            "type": "cu+du+ru",
+            "id": "a4d48045771c4ce09424"
+          }
+        ],
+        "status": 2,
+        "laston": "2024-04-12 21:44:57.011599",
+        "lastoff": "2023-12-29 11:31:29.128311",
+        "components-info": {
+          "a4d48045771c4ce09424": {
+            "firm": "ITRI",
+            "modelname": "A001",
+            "components-sw-inventory": {
+              "software-inventory": {
+                "software-slot": [
+                  {
+                    "name": "slot-1",
+                    "status": "VALID",
+                    "active": "true",
+                    "running": "true",
+                    "access": "READ_ONLY",
+                    "vendor-code": "K2",
+                    "build-id": "b01",
+                    "build-name": "product-default",
+                    "build-version": "0.1.0",
+                    "files": {
+                      "name": "file-1",
+                      "version": "0.2.3",
+                      "local-path": "~/some_dir/",
+                      "integrity": "OK"
+                    }
+                  },
+                  {
+                    "name": "slot-2",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-3",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-4",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      {
+        "info": {
+          "bs-conf": {
+            "plmn-id": {
+              "mcc": "466",
+              "mnc": "55"
+            },
+            "nci": "000028108",
+            "pci": 157,
+            "nrarfcn-dl": 723333,
+            "nrarfcn-ul": 723333,
+            "duplex-mode": "",
+            "channel-bandwidth": 20,
+            "tac": "3000",
+            "tx-power": 4
+          },
+          "gNBId": 10,
+          "gNBIdLength": 22,
+          "gNB-type": "SA",
+          "gNBCUName": "cu1",
+          "pLMNId_MCC": "466",
+          "pLMNId_MNC": "55",
+          "id": "0"
+        },
+        "extension_info": [
+          {
+            "gNBId": 10,
+            "gNBIdLength": 22,
+            "cellLocalId": "100001000",
+            "nci": "000028108",
+            "NRCellCU": {
+              "db": {
+                "componentId": "38b0f49a811646599ec1",
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              },
+              "ds": {
+                "componentId": "38b0f49a811646599ec1",
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              }
+            },
+            "gNBCUFunction": {
+              "db": {
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "38b0f49a811646599ec1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "38b0f49a811646599ec1",
+                "id": "0"
+              }
+            },
+            "peeParametersList_CU": {
+              "db": {
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_CU": {
+              "db": {
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_CU": {
+              "db": {
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_CU": {
+              "db": {
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              }
+            },
+            "EP_NgC": {
+              "db": {
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.5",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.5",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.5",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.5",
+                "id": "0"
+              }
+            },
+            "EP_NgU": {
+              "db": {
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.6",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.6",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.6",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.6",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellCU": {
+              "db": {
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "gNBDUFunction": {
+              "db": {
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "38b0f49a811646599ec1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "38b0f49a811646599ec1",
+                "id": "0"
+              }
+            },
+            "NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 157,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "componentId": "38b0f49a811646599ec1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 100,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "id": "0",
+                "componentId": "38b0f49a811646599ec1"
+              }
+            },
+            "peeParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrierRef_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              }
+            },
+            "bWPRef_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrier": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 4,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "bSChannelBwDL": 20,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 10,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 649788,
+                "arfcnUL": 649788,
+                "bSChannelBwDL": 100,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              }
+            },
+            "BWP": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRSector": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "idRef": "0",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.1111",
+                "siteLongitude": "10.2222",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "idRef": "0",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.1111",
+                "siteLongitude": "10.2222",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRSector": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "idRef": "0",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "idRef": "0",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "peeParametersList_BWP": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "idRef": "0",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.3333",
+                "siteLongitude": "10.4444",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "idRef": "0",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.3333",
+                "siteLongitude": "10.4444",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_BWP": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "idRef": "0",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 10,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "idRef": "0",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            }
+          }
+        ],
+        "cellInfo": {},
+        "anr": {
+          "anr-son-output": {
+            "neighbor": [
+              {
+                "id": "",
+                "nci": "00001c108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 152,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000040108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 153,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000018108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 140,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "00002c108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 154,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000024002",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "66"
+                },
+                "nrarfcn": 4850,
+                "pci": 159,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000024001",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "66"
+                },
+                "nrarfcn": 4850,
+                "pci": 158,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000024003",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "66"
+                },
+                "nrarfcn": 4850,
+                "pci": 137,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000024004",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "66"
+                },
+                "nrarfcn": 4850,
+                "pci": 155,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "00003c108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 160,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000014108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 142,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000030108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 141,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000044108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 143,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000034108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 144,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000020108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 145,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              }
+            ]
+          }
+        },
+        "pci": {},
+        "cco": {},
+        "id": "c9bb081540ea4752982f",
+        "name": "BS10",
+        "ip": "",
+        "port": "",
+        "position": "[121.044555,24.775007]",
+        "description": "BS10",
+        "bstype": 1,
+        "components": [
+          {
+            "type": "cu+du+ru",
+            "id": "38b0f49a811646599ec1"
+          }
+        ],
+        "status": 2,
+        "laston": "2024-04-12 21:44:57.082303",
+        "lastoff": "2023-12-29 07:33:20.038323",
+        "components-info": {
+          "38b0f49a811646599ec1": {
+            "firm": "ITRI",
+            "modelname": "A001",
+            "components-sw-inventory": {
+              "software-inventory": {
+                "software-slot": [
+                  {
+                    "name": "slot-1",
+                    "status": "VALID",
+                    "active": "true",
+                    "running": "true",
+                    "access": "READ_ONLY",
+                    "vendor-code": "K2",
+                    "build-id": "b01",
+                    "build-name": "product-default",
+                    "build-version": "0.1.0",
+                    "files": {
+                      "name": "file-1",
+                      "version": "0.2.3",
+                      "local-path": "~/some_dir/",
+                      "integrity": "OK"
+                    }
+                  },
+                  {
+                    "name": "slot-2",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-3",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-4",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      {
+        "info": {
+          "bs-conf": {
+            "plmn-id": {
+              "mcc": "466",
+              "mnc": "55"
+            },
+            "nci": "000034108",
+            "pci": 144,
+            "nrarfcn-dl": 723333,
+            "nrarfcn-ul": 723333,
+            "duplex-mode": "",
+            "channel-bandwidth": 20,
+            "tac": "3000",
+            "tx-power": 4
+          },
+          "gNBId": 13,
+          "gNBIdLength": 22,
+          "gNB-type": "SA",
+          "gNBCUName": "cu1",
+          "pLMNId_MCC": "466",
+          "pLMNId_MNC": "55",
+          "id": "0"
+        },
+        "extension_info": [
+          {
+            "gNBId": 13,
+            "gNBIdLength": 22,
+            "cellLocalId": "100001000",
+            "nci": "000034108",
+            "NRCellCU": {
+              "db": {
+                "componentId": "5ae9c2ee3c9f4437811f",
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              },
+              "ds": {
+                "componentId": "5ae9c2ee3c9f4437811f",
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              }
+            },
+            "gNBCUFunction": {
+              "db": {
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "5ae9c2ee3c9f4437811f",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "5ae9c2ee3c9f4437811f",
+                "id": "0"
+              }
+            },
+            "peeParametersList_CU": {
+              "db": {
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_CU": {
+              "db": {
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_CU": {
+              "db": {
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_CU": {
+              "db": {
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              }
+            },
+            "EP_NgC": {
+              "db": {
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.5",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.5",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.5",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.5",
+                "id": "0"
+              }
+            },
+            "EP_NgU": {
+              "db": {
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.6",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.6",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.6",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.6",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellCU": {
+              "db": {
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "gNBDUFunction": {
+              "db": {
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "5ae9c2ee3c9f4437811f",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "5ae9c2ee3c9f4437811f",
+                "id": "0"
+              }
+            },
+            "NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 144,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "componentId": "5ae9c2ee3c9f4437811f",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 100,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "id": "0",
+                "componentId": "5ae9c2ee3c9f4437811f"
+              }
+            },
+            "peeParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrierRef_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              }
+            },
+            "bWPRef_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrier": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 4,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "bSChannelBwDL": 20,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 10,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 649788,
+                "arfcnUL": 649788,
+                "bSChannelBwDL": 100,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              }
+            },
+            "BWP": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 13,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRSector": null,
+            "vnfParametersList_NRSector": null,
+            "peeParametersList_BWP": null,
+            "vnfParametersList_BWP": null
+          }
+        ],
+        "cellInfo": {},
+        "anr": {
+          "anr-son-output": {
+            "neighbor": [
+              {
+                "id": "",
+                "nci": "00003c108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "0",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 160,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": "111111"
+              },
+              {
+                "id": "",
+                "nci": "000038108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "0",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 156,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": "111111"
+              },
+              {
+                "id": "",
+                "nci": "000030108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "0",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 141,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": "111111"
+              }
+            ]
+          }
+        },
+        "pci": {},
+        "cco": {},
+        "id": "dac6f2a55f774233bae4",
+        "name": "BS13",
+        "ip": "",
+        "port": "",
+        "position": "[121.046205,24.775695]",
+        "description": "BS13",
+        "bstype": 1,
+        "components": [
+          {
+            "type": "cu+du+ru",
+            "id": "5ae9c2ee3c9f4437811f"
+          }
+        ],
+        "status": 2,
+        "laston": "2024-04-12 21:44:57.186204",
+        "lastoff": "2023-12-30 08:21:08.685877",
+        "components-info": {
+          "5ae9c2ee3c9f4437811f": {
+            "firm": "ITRI",
+            "modelname": "A001",
+            "components-sw-inventory": {
+              "software-inventory": {
+                "software-slot": [
+                  {
+                    "name": "slot-1",
+                    "status": "VALID",
+                    "active": "true",
+                    "running": "true",
+                    "access": "READ_ONLY",
+                    "vendor-code": "K2",
+                    "build-id": "b01",
+                    "build-name": "product-default",
+                    "build-version": "0.1.0",
+                    "files": {
+                      "name": "file-1",
+                      "version": "0.2.3",
+                      "local-path": "~/some_dir/",
+                      "integrity": "OK"
+                    }
+                  },
+                  {
+                    "name": "slot-2",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-3",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-4",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      {
+        "info": {
+          "bs-conf": {
+            "plmn-id": {
+              "mcc": "466",
+              "mnc": "55"
+            },
+            "nci": "000020108",
+            "pci": 145,
+            "nrarfcn-dl": 723333,
+            "nrarfcn-ul": 723333,
+            "duplex-mode": "",
+            "channel-bandwidth": 20,
+            "tac": "3000",
+            "tx-power": 4
+          },
+          "gNBId": 8,
+          "gNBIdLength": 22,
+          "gNB-type": "SA",
+          "gNBCUName": "cu1",
+          "pLMNId_MCC": "466",
+          "pLMNId_MNC": "55",
+          "id": "0"
+        },
+        "extension_info": [
+          {
+            "gNBId": 8,
+            "gNBIdLength": 22,
+            "cellLocalId": "100001000",
+            "nci": "000020108",
+            "NRCellCU": {
+              "db": {
+                "componentId": "7583c14081f2465f9b1a",
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              },
+              "ds": {
+                "componentId": "7583c14081f2465f9b1a",
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "absoluteFrequencySSB": "100",
+                "sSBSubCarrierSpacing": "15",
+                "id": "0"
+              }
+            },
+            "gNBCUFunction": {
+              "db": {
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "7583c14081f2465f9b1a",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "gNB-type": "SA",
+                "gNBCUName": "cu1",
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "componentId": "7583c14081f2465f9b1a",
+                "id": "0"
+              }
+            },
+            "peeParametersList_CU": {
+              "db": {
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0001",
+                "siteLongitude": "10.0001",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_CU": {
+              "db": {
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_CU": {
+              "db": {
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_CU": {
+              "db": {
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.3",
+                "id": "0"
+              }
+            },
+            "EP_NgC": {
+              "db": {
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.5",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.5",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.5",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.5",
+                "id": "0"
+              }
+            },
+            "EP_NgU": {
+              "db": {
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.6",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.6",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.1.6",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.2.6",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0101",
+                "siteLongitude": "10.0101",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellCU": {
+              "db": {
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellCU": {
+              "db": {
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "gNBDUFunction": {
+              "db": {
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "7583c14081f2465f9b1a",
+                "id": "0"
+              },
+              "ds": {
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "gNBDUId": 11,
+                "gNBDUName": "du1",
+                "componentId": "7583c14081f2465f9b1a",
+                "id": "0"
+              }
+            },
+            "NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 145,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "componentId": "7583c14081f2465f9b1a",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "administrativeState": "Locked",
+                "nRPCI": 100,
+                "nRTAC": "3000",
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "arfcnSUL": 2079415,
+                "bSChannelBwDL": 20,
+                "ssbFrequency": 9500,
+                "ssbPeriodicity": 5,
+                "ssbSubCarrierSpacing": 15,
+                "ssbOffset": 100,
+                "ssbDuration": 3,
+                "bSChannelBwUL": 1000,
+                "bSChannelBwSUL": 1000,
+                "id": "0",
+                "componentId": "7583c14081f2465f9b1a"
+              }
+            },
+            "peeParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0202",
+                "siteLongitude": "10.0202",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "EP_F1C_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.1",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.1",
+                "id": "0"
+              }
+            },
+            "EP_F1U_DU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "localAddress_ip_addr": "1.1.2.3",
+                "localAddress_vlan_id": "1",
+                "remoteAddress": "1.1.1.3",
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "siteIdentification": "bbb",
+                "siteLatitude": "10.0303",
+                "siteLongitude": "10.3033",
+                "siteDescription": "aaa",
+                "equipmentType": "RRU",
+                "environmentType": "Indoor",
+                "powerInterface": "AC",
+                "id": "0"
+              }
+            },
+            "vnfParametersList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "autoScalable": true,
+                "flavourId": "1",
+                "vnfInstanceId": "1",
+                "vnfdId": "1",
+                "id": "0"
+              }
+            },
+            "s_NSSAI_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "s_NSSAI": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrierRef_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "NRSectorCarrierRef": 0,
+                "id": "0"
+              }
+            },
+            "bWPRef_leafList_NRCellDU": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "cellLocalId": "100001000",
+                "bWPRef": 0,
+                "id": "0"
+              }
+            },
+            "NRSectorCarrier": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 4,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 723333,
+                "arfcnUL": 723333,
+                "bSChannelBwDL": 20,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "txDirection": "DL",
+                "configuredMaxTxPower": 10,
+                "configuredMaxTxEIRP": 10,
+                "arfcnDL": 649788,
+                "arfcnUL": 649788,
+                "bSChannelBwDL": 100,
+                "bSChannelBwUL": 100,
+                "id": "0"
+              }
+            },
+            "BWP": {
+              "db": {
+                "gNBDUId": 11,
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              },
+              "ds": {
+                "gNBDUId": 11,
+                "gNBId": 8,
+                "gNBIdLength": 22,
+                "pLMNId_MCC": "466",
+                "pLMNId_MNC": "55",
+                "bwpContext": 0,
+                "isInitialBwp": 0,
+                "subCarrierSpacing": 15,
+                "cyclicPrefix": 0,
+                "startRB": "1",
+                "numberOfRBs": 25,
+                "id": "0"
+              }
+            },
+            "peeParametersList_NRSector": null,
+            "vnfParametersList_NRSector": null,
+            "peeParametersList_BWP": null,
+            "vnfParametersList_BWP": null
+          }
+        ],
+        "cellInfo": {},
+        "anr": {
+          "anr-son-output": {
+            "neighbor": [
+              {
+                "id": "",
+                "nci": "000018108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 140,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000024002",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "66"
+                },
+                "nrarfcn": 4850,
+                "pci": 159,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000024001",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "66"
+                },
+                "nrarfcn": 4850,
+                "pci": 158,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000024003",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "66"
+                },
+                "nrarfcn": 4850,
+                "pci": 137,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000014108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 142,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000004108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 139,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000028108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 157,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              },
+              {
+                "id": "",
+                "nci": "000010108",
+                "enable": "0",
+                "alias": "xxxxxxxxxxxxxxxxxx",
+                "must-include": "",
+                "plmn-id": {
+                  "mcc": "466",
+                  "mnc": "55"
+                },
+                "nrarfcn": 4850,
+                "pci": 149,
+                "q-offset": "",
+                "cio": "",
+                "rs-tx-power": "",
+                "blacklisted": "",
+                "tac": ""
+              }
+            ]
+          }
+        },
+        "pci": {},
+        "cco": {},
+        "id": "e4f0013574684be19deb",
+        "name": "BS8",
+        "ip": "",
+        "port": "",
+        "position": "[121.042304,24.774599]",
+        "description": "BS08",
+        "bstype": 1,
+        "components": [
+          {
+            "type": "cu+du+ru",
+            "id": "7583c14081f2465f9b1a"
+          }
+        ],
+        "status": 2,
+        "laston": "2024-04-12 21:44:57.298456",
+        "lastoff": "2023-12-30 02:50:10.569725",
+        "components-info": {
+          "7583c14081f2465f9b1a": {
+            "firm": "ITRI",
+            "modelname": "A001",
+            "components-sw-inventory": {
+              "software-inventory": {
+                "software-slot": [
+                  {
+                    "name": "slot-1",
+                    "status": "VALID",
+                    "active": "true",
+                    "running": "true",
+                    "access": "READ_ONLY",
+                    "vendor-code": "K2",
+                    "build-id": "b01",
+                    "build-name": "product-default",
+                    "build-version": "0.1.0",
+                    "files": {
+                      "name": "file-1",
+                      "version": "0.2.3",
+                      "local-path": "~/some_dir/",
+                      "integrity": "OK"
+                    }
+                  },
+                  {
+                    "name": "slot-2",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-3",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  },
+                  {
+                    "name": "slot-4",
+                    "status": "EMPTY",
+                    "active": "false",
+                    "running": "false",
+                    "access": "READ_WRITE"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    ];
+    
+    
     dist_bsInfo_local: BSInfo_dist[] = [
         {
             "info": [
@@ -16358,6 +27830,4006 @@
           "status": 2,
           "laston": "2024-03-29 02:21:51.024416",
           "lastoff": null,
+          "components-info": {}
+        },
+        {
+          "info": {},
+          "extension_info": [
+            {
+              "gNBId": 9,
+              "gNBIdLength": 22,
+              "cellLocalId": "1",
+              "nci": "000024001",
+              "gNBCUFunction": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "gNB-type": "SA",
+                  "gNBCUName": "cu1",
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "componentId": "1ebfdbd887034b439104",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "gNB-type": "SA",
+                  "gNBCUName": "cu1",
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "componentId": "1ebfdbd887034b439104",
+                  "id": "0"
+                }
+              },
+              "NRCellCU": {
+                "db": {
+                  "componentId": "4d926256a64443349aa1",
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "1",
+                  "absoluteFrequencySSB": "100",
+                  "sSBSubCarrierSpacing": "15",
+                  "id": "0"
+                },
+                "ds": {
+                  "componentId": "4d926256a64443349aa1",
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "1",
+                  "absoluteFrequencySSB": "100",
+                  "sSBSubCarrierSpacing": "15",
+                  "id": "0"
+                }
+              },
+              "peeParametersList_CU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0001",
+                  "siteLongitude": "10.0001",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0001",
+                  "siteLongitude": "10.0001",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                }
+              },
+              "vnfParametersList_CU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                }
+              },
+              "EP_F1C_CU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.1",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.1",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.1",
+                  "id": "0"
+                }
+              },
+              "EP_F1U_CU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.3",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.3",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.3",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.3",
+                  "id": "0"
+                }
+              },
+              "EP_NgC": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.5",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.5",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.5",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.5",
+                  "id": "0"
+                }
+              },
+              "EP_NgU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.6",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.6",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.6",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.6",
+                  "id": "0"
+                }
+              },
+              "peeParametersList_NRCellCU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "1",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0101",
+                  "siteLongitude": "10.0101",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "1",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0101",
+                  "siteLongitude": "10.0101",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                }
+              },
+              "vnfParametersList_NRCellCU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "1",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "1",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                }
+              },
+              "s_NSSAI_leafList_NRCellCU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "1",
+                  "s_NSSAI": 0,
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "1",
+                  "s_NSSAI": 0,
+                  "id": "0"
+                }
+              },
+              "gNBDUFunction": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "gNBDUId": 12,
+                  "gNBDUName": "du2",
+                  "componentId": "f026604b16ab4651b1a3",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "gNBDUId": 12,
+                  "gNBDUName": "du2",
+                  "componentId": "f026604b16ab4651b1a3",
+                  "id": "0"
+                }
+              },
+              "NRCellDU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "1",
+                  "administrativeState": "Locked",
+                  "nRPCI": 158,
+                  "nRTAC": "3000",
+                  "arfcnDL": 723333,
+                  "arfcnUL": 723333,
+                  "arfcnSUL": 2079415,
+                  "bSChannelBwDL": 20,
+                  "ssbFrequency": 9500,
+                  "ssbPeriodicity": 5,
+                  "ssbSubCarrierSpacing": 15,
+                  "ssbOffset": 100,
+                  "ssbDuration": 3,
+                  "bSChannelBwUL": 1000,
+                  "bSChannelBwSUL": 1000,
+                  "componentId": "4d926256a64443349aa1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "1",
+                  "administrativeState": "Locked",
+                  "nRPCI": 100,
+                  "nRTAC": "3000",
+                  "arfcnDL": 723333,
+                  "arfcnUL": 723333,
+                  "arfcnSUL": 2079415,
+                  "bSChannelBwDL": 20,
+                  "ssbFrequency": 9500,
+                  "ssbPeriodicity": 5,
+                  "ssbSubCarrierSpacing": 15,
+                  "ssbOffset": 100,
+                  "ssbDuration": 3,
+                  "bSChannelBwUL": 1000,
+                  "bSChannelBwSUL": 1000,
+                  "id": "0",
+                  "componentId": "4d926256a64443349aa1"
+                }
+              },
+              "peeParametersList_DU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0202",
+                  "siteLongitude": "10.0202",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0202",
+                  "siteLongitude": "10.0202",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                }
+              },
+              "vnfParametersList_DU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                }
+              },
+              "EP_F1C_DU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.2.2",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.1.2",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.2.2",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.1.2",
+                  "id": "0"
+                }
+              },
+              "EP_F1U_DU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.2.4",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.1.4",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.2.4",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.1.4",
+                  "id": "0"
+                }
+              },
+              "NRSectorCarrier": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "txDirection": "DL",
+                  "configuredMaxTxPower": 8,
+                  "configuredMaxTxEIRP": 10,
+                  "arfcnDL": 649788,
+                  "arfcnUL": 649788,
+                  "bSChannelBwDL": 100,
+                  "bSChannelBwUL": 100,
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "txDirection": "DL",
+                  "configuredMaxTxPower": 10,
+                  "configuredMaxTxEIRP": 10,
+                  "arfcnDL": 649788,
+                  "arfcnUL": 649788,
+                  "bSChannelBwDL": 100,
+                  "bSChannelBwUL": 100,
+                  "id": "0"
+                }
+              },
+              "BWP": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "bwpContext": 0,
+                  "isInitialBwp": 0,
+                  "subCarrierSpacing": 15,
+                  "cyclicPrefix": 0,
+                  "startRB": "1",
+                  "numberOfRBs": 25,
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "bwpContext": 0,
+                  "isInitialBwp": 0,
+                  "subCarrierSpacing": 15,
+                  "cyclicPrefix": 0,
+                  "startRB": "1",
+                  "numberOfRBs": 25,
+                  "id": "0"
+                }
+              },
+              "peeParametersList_NRSector": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "0",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.1111",
+                  "siteLongitude": "10.2222",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "0",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.1111",
+                  "siteLongitude": "10.2222",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                }
+              },
+              "vnfParametersList_NRSector": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "0",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "0",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                }
+              },
+              "peeParametersList_NRCellDU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "1",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0303",
+                  "siteLongitude": "10.3033",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "1",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0303",
+                  "siteLongitude": "10.3033",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                }
+              },
+              "vnfParametersList_NRCellDU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "1",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "1",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                }
+              },
+              "s_NSSAI_leafList_NRCellDU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "1",
+                  "s_NSSAI": 0,
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "1",
+                  "s_NSSAI": 0,
+                  "id": "0"
+                }
+              },
+              "NRSectorCarrierRef_NRCellDU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "1",
+                  "NRSectorCarrierRef": 0,
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "1",
+                  "NRSectorCarrierRef": 0,
+                  "id": "0"
+                }
+              },
+              "bWPRef_leafList_NRCellDU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "1",
+                  "bWPRef": 0,
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "1",
+                  "bWPRef": 0,
+                  "id": "0"
+                }
+              },
+              "peeParametersList_BWP": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "0",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.3333",
+                  "siteLongitude": "10.4444",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "0",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.3333",
+                  "siteLongitude": "10.4444",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                }
+              },
+              "vnfParametersList_BWP": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "0",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "0",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                }
+              }
+            },
+            {
+              "gNBId": 9,
+              "gNBIdLength": 22,
+              "cellLocalId": "10",
+              "nci": "000024002",
+              "gNBCUFunction": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "gNB-type": "SA",
+                  "gNBCUName": "cu1",
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "componentId": "1ebfdbd887034b439104",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "gNB-type": "SA",
+                  "gNBCUName": "cu1",
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "componentId": "1ebfdbd887034b439104",
+                  "id": "0"
+                }
+              },
+              "NRCellCU": {
+                "db": {
+                  "componentId": "8ece726a4ebe4803b8be",
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "10",
+                  "absoluteFrequencySSB": "100",
+                  "sSBSubCarrierSpacing": "15",
+                  "id": "1"
+                },
+                "ds": {
+                  "componentId": "8ece726a4ebe4803b8be",
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "10",
+                  "absoluteFrequencySSB": "100",
+                  "sSBSubCarrierSpacing": "15",
+                  "id": "1"
+                }
+              },
+              "peeParametersList_CU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0001",
+                  "siteLongitude": "10.0001",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0001",
+                  "siteLongitude": "10.0001",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                }
+              },
+              "vnfParametersList_CU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                }
+              },
+              "EP_F1C_CU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.1",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.1",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.1",
+                  "id": "0"
+                }
+              },
+              "EP_F1U_CU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.3",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.3",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.3",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.3",
+                  "id": "0"
+                }
+              },
+              "EP_NgC": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.5",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.5",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.5",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.5",
+                  "id": "0"
+                }
+              },
+              "EP_NgU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.6",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.6",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.6",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.6",
+                  "id": "0"
+                }
+              },
+              "peeParametersList_NRCellCU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "10",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0101",
+                  "siteLongitude": "10.0101",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "1"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "10",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0101",
+                  "siteLongitude": "10.0101",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "1"
+                }
+              },
+              "vnfParametersList_NRCellCU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "10",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "1"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "10",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "1"
+                }
+              },
+              "s_NSSAI_leafList_NRCellCU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "10",
+                  "s_NSSAI": 1,
+                  "id": "1"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "10",
+                  "s_NSSAI": 1,
+                  "id": "1"
+                }
+              },
+              "gNBDUFunction": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "gNBDUId": 11,
+                  "gNBDUName": "du1",
+                  "componentId": "542ec6627f744df1bafd",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "gNBDUId": 11,
+                  "gNBDUName": "du1",
+                  "componentId": "542ec6627f744df1bafd",
+                  "id": "0"
+                }
+              },
+              "NRCellDU": {
+                "db": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "10",
+                  "administrativeState": "Locked",
+                  "nRPCI": 159,
+                  "nRTAC": "3000",
+                  "arfcnDL": 723333,
+                  "arfcnUL": 723333,
+                  "arfcnSUL": 2079415,
+                  "bSChannelBwDL": 20,
+                  "ssbFrequency": 9500,
+                  "ssbPeriodicity": 5,
+                  "ssbSubCarrierSpacing": 15,
+                  "ssbOffset": 100,
+                  "ssbDuration": 3,
+                  "bSChannelBwUL": 1000,
+                  "bSChannelBwSUL": 1000,
+                  "componentId": "8ece726a4ebe4803b8be",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "10",
+                  "administrativeState": "Locked",
+                  "nRPCI": 100,
+                  "nRTAC": "3000",
+                  "arfcnDL": 723333,
+                  "arfcnUL": 723333,
+                  "arfcnSUL": 2079415,
+                  "bSChannelBwDL": 20,
+                  "ssbFrequency": 9500,
+                  "ssbPeriodicity": 5,
+                  "ssbSubCarrierSpacing": 15,
+                  "ssbOffset": 100,
+                  "ssbDuration": 3,
+                  "bSChannelBwUL": 1000,
+                  "bSChannelBwSUL": 1000,
+                  "id": "0",
+                  "componentId": "8ece726a4ebe4803b8be"
+                }
+              },
+              "peeParametersList_DU": {
+                "db": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0202",
+                  "siteLongitude": "10.0202",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0202",
+                  "siteLongitude": "10.0202",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                }
+              },
+              "vnfParametersList_DU": {
+                "db": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                }
+              },
+              "EP_F1C_DU": {
+                "db": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.2.1",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.1.1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.2.1",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.1.1",
+                  "id": "0"
+                }
+              },
+              "EP_F1U_DU": {
+                "db": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.2.3",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.1.3",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.2.3",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.1.3",
+                  "id": "0"
+                }
+              },
+              "NRSectorCarrier": {
+                "db": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "txDirection": "DL",
+                  "configuredMaxTxPower": 17,
+                  "configuredMaxTxEIRP": 10,
+                  "arfcnDL": 649788,
+                  "arfcnUL": 649788,
+                  "bSChannelBwDL": 100,
+                  "bSChannelBwUL": 100,
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "txDirection": "DL",
+                  "configuredMaxTxPower": 10,
+                  "configuredMaxTxEIRP": 10,
+                  "arfcnDL": 649788,
+                  "arfcnUL": 649788,
+                  "bSChannelBwDL": 100,
+                  "bSChannelBwUL": 100,
+                  "id": "0"
+                }
+              },
+              "BWP": {
+                "db": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "bwpContext": 0,
+                  "isInitialBwp": 0,
+                  "subCarrierSpacing": 15,
+                  "cyclicPrefix": 0,
+                  "startRB": "1",
+                  "numberOfRBs": 25,
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "bwpContext": 0,
+                  "isInitialBwp": 0,
+                  "subCarrierSpacing": 15,
+                  "cyclicPrefix": 0,
+                  "startRB": "1",
+                  "numberOfRBs": 25,
+                  "id": "0"
+                }
+              },
+              "peeParametersList_NRSector": {
+                "db": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "0",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.1111",
+                  "siteLongitude": "10.2222",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "0",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.1111",
+                  "siteLongitude": "10.2222",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                }
+              },
+              "vnfParametersList_NRSector": {
+                "db": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "0",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "0",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                }
+              },
+              "peeParametersList_NRCellDU": {
+                "db": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "10",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0303",
+                  "siteLongitude": "10.3033",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "10",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0303",
+                  "siteLongitude": "10.3033",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                }
+              },
+              "vnfParametersList_NRCellDU": {
+                "db": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "10",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "10",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                }
+              },
+              "s_NSSAI_leafList_NRCellDU": {
+                "db": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "10",
+                  "s_NSSAI": 0,
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "10",
+                  "s_NSSAI": 0,
+                  "id": "0"
+                }
+              },
+              "NRSectorCarrierRef_NRCellDU": {
+                "db": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "10",
+                  "NRSectorCarrierRef": 0,
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "10",
+                  "NRSectorCarrierRef": 0,
+                  "id": "0"
+                }
+              },
+              "bWPRef_leafList_NRCellDU": {
+                "db": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "10",
+                  "bWPRef": 0,
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "10",
+                  "bWPRef": 0,
+                  "id": "0"
+                }
+              },
+              "peeParametersList_BWP": {
+                "db": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "0",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.3333",
+                  "siteLongitude": "10.4444",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "0",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.3333",
+                  "siteLongitude": "10.4444",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                }
+              },
+              "vnfParametersList_BWP": {
+                "db": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "0",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 11,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "0",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                }
+              }
+            },
+            {
+              "gNBId": 9,
+              "gNBIdLength": 22,
+              "cellLocalId": "11",
+              "nci": "000024003",
+              "gNBCUFunction": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "gNB-type": "SA",
+                  "gNBCUName": "cu1",
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "componentId": "1ebfdbd887034b439104",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "gNB-type": "SA",
+                  "gNBCUName": "cu1",
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "componentId": "1ebfdbd887034b439104",
+                  "id": "0"
+                }
+              },
+              "NRCellCU": {
+                "db": {
+                  "componentId": "9302a2a119484ef1ab67",
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "11",
+                  "absoluteFrequencySSB": "100",
+                  "sSBSubCarrierSpacing": "15",
+                  "id": "2"
+                },
+                "ds": {
+                  "componentId": "9302a2a119484ef1ab67",
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "11",
+                  "absoluteFrequencySSB": "100",
+                  "sSBSubCarrierSpacing": "15",
+                  "id": "2"
+                }
+              },
+              "peeParametersList_CU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0001",
+                  "siteLongitude": "10.0001",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0001",
+                  "siteLongitude": "10.0001",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                }
+              },
+              "vnfParametersList_CU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                }
+              },
+              "EP_F1C_CU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.1",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.1",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.1",
+                  "id": "0"
+                }
+              },
+              "EP_F1U_CU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.3",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.3",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.3",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.3",
+                  "id": "0"
+                }
+              },
+              "EP_NgC": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.5",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.5",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.5",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.5",
+                  "id": "0"
+                }
+              },
+              "EP_NgU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.6",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.6",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.6",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.6",
+                  "id": "0"
+                }
+              },
+              "peeParametersList_NRCellCU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "11",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0101",
+                  "siteLongitude": "10.0101",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "2"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "11",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0101",
+                  "siteLongitude": "10.0101",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "2"
+                }
+              },
+              "vnfParametersList_NRCellCU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "11",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "2"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "11",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "2"
+                }
+              },
+              "s_NSSAI_leafList_NRCellCU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "11",
+                  "s_NSSAI": 2,
+                  "id": "2"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "11",
+                  "s_NSSAI": 2,
+                  "id": "2"
+                }
+              },
+              "gNBDUFunction": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "gNBDUId": 12,
+                  "gNBDUName": "du2",
+                  "componentId": "f026604b16ab4651b1a3",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "gNBDUId": 12,
+                  "gNBDUName": "du2",
+                  "componentId": "f026604b16ab4651b1a3",
+                  "id": "0"
+                }
+              },
+              "NRCellDU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "11",
+                  "administrativeState": "Locked",
+                  "nRPCI": 137,
+                  "nRTAC": "3000",
+                  "arfcnDL": 723333,
+                  "arfcnUL": 723333,
+                  "arfcnSUL": 2079415,
+                  "bSChannelBwDL": 20,
+                  "ssbFrequency": 9500,
+                  "ssbPeriodicity": 5,
+                  "ssbSubCarrierSpacing": 15,
+                  "ssbOffset": 100,
+                  "ssbDuration": 3,
+                  "bSChannelBwUL": 1000,
+                  "bSChannelBwSUL": 1000,
+                  "componentId": "9302a2a119484ef1ab67",
+                  "id": "1"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "11",
+                  "administrativeState": "Locked",
+                  "nRPCI": 100,
+                  "nRTAC": "3000",
+                  "arfcnDL": 723333,
+                  "arfcnUL": 723333,
+                  "arfcnSUL": 2079415,
+                  "bSChannelBwDL": 20,
+                  "ssbFrequency": 9500,
+                  "ssbPeriodicity": 5,
+                  "ssbSubCarrierSpacing": 15,
+                  "ssbOffset": 100,
+                  "ssbDuration": 3,
+                  "bSChannelBwUL": 1000,
+                  "bSChannelBwSUL": 1000,
+                  "id": "1",
+                  "componentId": "9302a2a119484ef1ab67"
+                }
+              },
+              "peeParametersList_DU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0202",
+                  "siteLongitude": "10.0202",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0202",
+                  "siteLongitude": "10.0202",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                }
+              },
+              "vnfParametersList_DU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                }
+              },
+              "EP_F1C_DU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.2.2",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.1.2",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.2.2",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.1.2",
+                  "id": "0"
+                }
+              },
+              "EP_F1U_DU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.2.4",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.1.4",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.2.4",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.1.4",
+                  "id": "0"
+                }
+              },
+              "NRSectorCarrier": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "txDirection": "DL",
+                  "configuredMaxTxPower": 8,
+                  "configuredMaxTxEIRP": 10,
+                  "arfcnDL": 649788,
+                  "arfcnUL": 649788,
+                  "bSChannelBwDL": 100,
+                  "bSChannelBwUL": 100,
+                  "id": "1"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "txDirection": "DL",
+                  "configuredMaxTxPower": 10,
+                  "configuredMaxTxEIRP": 10,
+                  "arfcnDL": 649788,
+                  "arfcnUL": 649788,
+                  "bSChannelBwDL": 100,
+                  "bSChannelBwUL": 100,
+                  "id": "1"
+                }
+              },
+              "BWP": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "bwpContext": 0,
+                  "isInitialBwp": 0,
+                  "subCarrierSpacing": 15,
+                  "cyclicPrefix": 0,
+                  "startRB": "1",
+                  "numberOfRBs": 25,
+                  "id": "1"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "bwpContext": 0,
+                  "isInitialBwp": 0,
+                  "subCarrierSpacing": 15,
+                  "cyclicPrefix": 0,
+                  "startRB": "1",
+                  "numberOfRBs": 25,
+                  "id": "1"
+                }
+              },
+              "peeParametersList_NRSector": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "1",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.1111",
+                  "siteLongitude": "10.2222",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "1",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.1111",
+                  "siteLongitude": "10.2222",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                }
+              },
+              "vnfParametersList_NRSector": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "1",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "1",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                }
+              },
+              "peeParametersList_NRCellDU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "11",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0303",
+                  "siteLongitude": "10.3033",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "11",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0303",
+                  "siteLongitude": "10.3033",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                }
+              },
+              "vnfParametersList_NRCellDU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "11",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "11",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                }
+              },
+              "s_NSSAI_leafList_NRCellDU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "11",
+                  "s_NSSAI": 0,
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "11",
+                  "s_NSSAI": 0,
+                  "id": "0"
+                }
+              },
+              "NRSectorCarrierRef_NRCellDU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "11",
+                  "NRSectorCarrierRef": 1,
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "11",
+                  "NRSectorCarrierRef": 1,
+                  "id": "0"
+                }
+              },
+              "bWPRef_leafList_NRCellDU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "11",
+                  "bWPRef": 1,
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "11",
+                  "bWPRef": 1,
+                  "id": "0"
+                }
+              },
+              "peeParametersList_BWP": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "1",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.3333",
+                  "siteLongitude": "10.4444",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "1",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.3333",
+                  "siteLongitude": "10.4444",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                }
+              },
+              "vnfParametersList_BWP": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "1",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "1",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                }
+              }
+            },
+            {
+              "gNBId": 9,
+              "gNBIdLength": 22,
+              "cellLocalId": "100",
+              "nci": "000024004",
+              "gNBCUFunction": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "gNB-type": "SA",
+                  "gNBCUName": "cu1",
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "componentId": "1ebfdbd887034b439104",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "gNB-type": "SA",
+                  "gNBCUName": "cu1",
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "componentId": "1ebfdbd887034b439104",
+                  "id": "0"
+                }
+              },
+              "NRCellCU": {
+                "db": {
+                  "componentId": "56fc9a6be991472f8b86",
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "100",
+                  "absoluteFrequencySSB": "100",
+                  "sSBSubCarrierSpacing": "15",
+                  "id": "3"
+                },
+                "ds": {
+                  "componentId": "56fc9a6be991472f8b86",
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "100",
+                  "absoluteFrequencySSB": "100",
+                  "sSBSubCarrierSpacing": "15",
+                  "id": "3"
+                }
+              },
+              "peeParametersList_CU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0001",
+                  "siteLongitude": "10.0001",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0001",
+                  "siteLongitude": "10.0001",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                }
+              },
+              "vnfParametersList_CU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                }
+              },
+              "EP_F1C_CU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.1",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.1",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.1",
+                  "id": "0"
+                }
+              },
+              "EP_F1U_CU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.3",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.3",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.3",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.3",
+                  "id": "0"
+                }
+              },
+              "EP_NgC": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.5",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.5",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.5",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.5",
+                  "id": "0"
+                }
+              },
+              "EP_NgU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.6",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.6",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.1.6",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.2.6",
+                  "id": "0"
+                }
+              },
+              "peeParametersList_NRCellCU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "100",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0101",
+                  "siteLongitude": "10.0101",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "3"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "100",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0101",
+                  "siteLongitude": "10.0101",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "3"
+                }
+              },
+              "vnfParametersList_NRCellCU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "100",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "3"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "100",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "3"
+                }
+              },
+              "s_NSSAI_leafList_NRCellCU": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "100",
+                  "s_NSSAI": 3,
+                  "id": "3"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "100",
+                  "s_NSSAI": 3,
+                  "id": "3"
+                }
+              },
+              "gNBDUFunction": {
+                "db": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "gNBDUId": 12,
+                  "gNBDUName": "du2",
+                  "componentId": "f026604b16ab4651b1a3",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "gNBDUId": 12,
+                  "gNBDUName": "du2",
+                  "componentId": "f026604b16ab4651b1a3",
+                  "id": "0"
+                }
+              },
+              "NRCellDU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "100",
+                  "administrativeState": "Locked",
+                  "nRPCI": 155,
+                  "nRTAC": "3000",
+                  "arfcnDL": 723333,
+                  "arfcnUL": 723333,
+                  "arfcnSUL": 2079415,
+                  "bSChannelBwDL": 20,
+                  "ssbFrequency": 9500,
+                  "ssbPeriodicity": 5,
+                  "ssbSubCarrierSpacing": 15,
+                  "ssbOffset": 100,
+                  "ssbDuration": 3,
+                  "bSChannelBwUL": 1000,
+                  "bSChannelBwSUL": 1000,
+                  "componentId": "56fc9a6be991472f8b86",
+                  "id": "2"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "100",
+                  "administrativeState": "Locked",
+                  "nRPCI": 100,
+                  "nRTAC": "3000",
+                  "arfcnDL": 723333,
+                  "arfcnUL": 723333,
+                  "arfcnSUL": 2079415,
+                  "bSChannelBwDL": 20,
+                  "ssbFrequency": 9500,
+                  "ssbPeriodicity": 5,
+                  "ssbSubCarrierSpacing": 15,
+                  "ssbOffset": 100,
+                  "ssbDuration": 3,
+                  "bSChannelBwUL": 1000,
+                  "bSChannelBwSUL": 1000,
+                  "id": "2",
+                  "componentId": "56fc9a6be991472f8b86"
+                }
+              },
+              "peeParametersList_DU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0202",
+                  "siteLongitude": "10.0202",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0202",
+                  "siteLongitude": "10.0202",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                }
+              },
+              "vnfParametersList_DU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                }
+              },
+              "EP_F1C_DU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.2.2",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.1.2",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.2.2",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.1.2",
+                  "id": "0"
+                }
+              },
+              "EP_F1U_DU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.2.4",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.1.4",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "localAddress_ip_addr": "1.1.2.4",
+                  "localAddress_vlan_id": "1",
+                  "remoteAddress": "1.1.1.4",
+                  "id": "0"
+                }
+              },
+              "NRSectorCarrier": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "txDirection": "DL",
+                  "configuredMaxTxPower": 5,
+                  "configuredMaxTxEIRP": 10,
+                  "arfcnDL": 649788,
+                  "arfcnUL": 649788,
+                  "bSChannelBwDL": 100,
+                  "bSChannelBwUL": 100,
+                  "id": "2"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "txDirection": "DL",
+                  "configuredMaxTxPower": 10,
+                  "configuredMaxTxEIRP": 10,
+                  "arfcnDL": 649788,
+                  "arfcnUL": 649788,
+                  "bSChannelBwDL": 100,
+                  "bSChannelBwUL": 100,
+                  "id": "2"
+                }
+              },
+              "BWP": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "bwpContext": 0,
+                  "isInitialBwp": 0,
+                  "subCarrierSpacing": 15,
+                  "cyclicPrefix": 0,
+                  "startRB": "1",
+                  "numberOfRBs": 25,
+                  "id": "2"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "bwpContext": 0,
+                  "isInitialBwp": 0,
+                  "subCarrierSpacing": 15,
+                  "cyclicPrefix": 0,
+                  "startRB": "1",
+                  "numberOfRBs": 25,
+                  "id": "2"
+                }
+              },
+              "peeParametersList_NRSector": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "2",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.1111",
+                  "siteLongitude": "10.2222",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "2",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.1111",
+                  "siteLongitude": "10.2222",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                }
+              },
+              "vnfParametersList_NRSector": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "2",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "2",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                }
+              },
+              "peeParametersList_NRCellDU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "100",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0303",
+                  "siteLongitude": "10.3033",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "100",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.0303",
+                  "siteLongitude": "10.3033",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                }
+              },
+              "vnfParametersList_NRCellDU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "100",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "100",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                }
+              },
+              "s_NSSAI_leafList_NRCellDU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "100",
+                  "s_NSSAI": 0,
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "100",
+                  "s_NSSAI": 0,
+                  "id": "0"
+                }
+              },
+              "NRSectorCarrierRef_NRCellDU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "100",
+                  "NRSectorCarrierRef": 2,
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "100",
+                  "NRSectorCarrierRef": 2,
+                  "id": "0"
+                }
+              },
+              "bWPRef_leafList_NRCellDU": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "100",
+                  "bWPRef": 2,
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "cellLocalId": "100",
+                  "bWPRef": 2,
+                  "id": "0"
+                }
+              },
+              "peeParametersList_BWP": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "2",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.3333",
+                  "siteLongitude": "10.4444",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "2",
+                  "siteIdentification": "bbb",
+                  "siteLatitude": "10.3333",
+                  "siteLongitude": "10.4444",
+                  "siteDescription": "aaa",
+                  "equipmentType": "RRU",
+                  "environmentType": "Indoor",
+                  "powerInterface": "AC",
+                  "id": "0"
+                }
+              },
+              "vnfParametersList_BWP": {
+                "db": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "2",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                },
+                "ds": {
+                  "gNBDUId": 12,
+                  "gNBId": 9,
+                  "gNBIdLength": 22,
+                  "pLMNId_MCC": "466",
+                  "pLMNId_MNC": "66",
+                  "idRef": "2",
+                  "autoScalable": true,
+                  "flavourId": "1",
+                  "vnfInstanceId": "1",
+                  "vnfdId": "1",
+                  "id": "0"
+                }
+              }
+            }
+          ],
+          "cellInfo": {
+            "8ece726a4ebe4803b8be": "000024002",
+            "4d926256a64443349aa1": "000024001",
+            "9302a2a119484ef1ab67": "000024003",
+            "56fc9a6be991472f8b86": "000024004"
+          },
+          "anr": {
+            "000024001": {
+              "anr-son-output": {
+                "neighbor": [
+                  {
+                    "nci": "00001c108",
+                    "pci": 152,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000040108",
+                    "pci": 153,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000018108",
+                    "pci": 140,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "00002c108",
+                    "pci": 154,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000024002",
+                    "pci": 159,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "66"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000024003",
+                    "pci": 137,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "66"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000024004",
+                    "pci": 155,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "66"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000014108",
+                    "pci": 142,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000030108",
+                    "pci": 141,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000044108",
+                    "pci": 143,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000028108",
+                    "pci": 157,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000034108",
+                    "pci": 144,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000020108",
+                    "pci": 145,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  }
+                ]
+              }
+            },
+            "000024002": {
+              "anr-son-output": {
+                "neighbor": [
+                  {
+                    "nci": "00001c108",
+                    "pci": 152,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "00004c108",
+                    "pci": 146,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000040108",
+                    "pci": 153,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000048108",
+                    "pci": 100,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "00002c108",
+                    "pci": 154,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000024001",
+                    "pci": 158,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "66"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000024003",
+                    "pci": 137,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "66"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000024004",
+                    "pci": 155,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "66"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "00003c108",
+                    "pci": 160,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000014108",
+                    "pci": 142,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000038108",
+                    "pci": 156,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000030108",
+                    "pci": 141,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000050108",
+                    "pci": 150,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000044108",
+                    "pci": 143,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000028108",
+                    "pci": 157,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000034108",
+                    "pci": 144,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000020108",
+                    "pci": 145,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  }
+                ]
+              }
+            },
+            "000024003": {
+              "anr-son-output": {
+                "neighbor": [
+                  {
+                    "nci": "000040108",
+                    "pci": 153,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "00002c108",
+                    "pci": 154,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000024002",
+                    "pci": 159,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "66"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000024001",
+                    "pci": 158,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "66"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000024004",
+                    "pci": 155,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "66"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000014108",
+                    "pci": 142,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000028108",
+                    "pci": 157,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000010108",
+                    "pci": 149,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000020108",
+                    "pci": 145,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  }
+                ]
+              }
+            },
+            "000024004": {
+              "anr-son-output": {
+                "neighbor": [
+                  {
+                    "nci": "000040108",
+                    "pci": 153,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "00002c108",
+                    "pci": 154,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000024002",
+                    "pci": 159,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "66"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000024001",
+                    "pci": 158,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "66"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000024003",
+                    "pci": 137,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "66"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000050108",
+                    "pci": 150,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  },
+                  {
+                    "nci": "000028108",
+                    "pci": 157,
+                    "nrarfcn": 4850,
+                    "plmn-id": {
+                      "mcc": "466",
+                      "mnc": "55"
+                    },
+                    "tac": "",
+                    "id": "0",
+                    "enable": "0",
+                    "alias": "xxxxxxxxxxxxxxxxxx",
+                    "cio": "",
+                    "blacklisted": "",
+                    "must-include": "",
+                    "q-offset": "",
+                    "rs-tx-power": "",
+                    "__itri_default___": 0
+                  }
+                ]
+              }
+            }
+          },
+          "pci": {},
+          "cco": {},
+          "id": "349b9f81afa54669b094",
+          "name": "BS99",
+          "ip": "",
+          "port": "",
+          "position": "",
+          "description": "BS099",
+          "bstype": 2,
+          "components": {
+            "1ebfdbd887034b439104": {
+              "542ec6627f744df1bafd": [
+                {
+                  "8ece726a4ebe4803b8be": "[121.045096,24.773931]"
+                }
+              ],
+              "f026604b16ab4651b1a3": [
+                {
+                  "4d926256a64443349aa1": "[121.044212,24.774544]"
+                },
+                {
+                  "9302a2a119484ef1ab67": "[121.043409,24.77402]"
+                },
+                {
+                  "56fc9a6be991472f8b86": "[121.044212,24.773144]"
+                }
+              ]
+            }
+          },
+          "status": 2,
+          "laston": "2024-04-12 04:11:20.861465",
+          "lastoff": "2023-12-27 08:04:10.562803",
           "components-info": {}
         }
     ];

--- a/src/app/shared/local-files/Field/For_multiCalculateBs_response.ts
+++ b/src/app/shared/local-files/Field/For_multiCalculateBs_response.ts
@@ -6,104 +6,2299 @@
  export class localCalculateSonResponse {
 
     // For calculateSON_Submit() Get local CalculateSonResponse
+
+    // 只有原鄰居基站多的狀況 04/11 Add 
+    /*
+      calculateSonResponse_local: ForCalculateSonResponse = {
+        "cco": {
+          "field": "e6700d701f8b41f8950e",
+          "cellIndividualResult": [
+            {
+              "gNBId": 16,
+              "txpower": 2,
+              "pLMNId_MCC": "466",
+              "cellLocalId": "00000100001000",
+              "pLMNId_MNC": "55"
+            },
+            {
+              "gNBId": 6,
+              "txpower": 2,
+              "pLMNId_MCC": "466",
+              "cellLocalId": "00000100001000",
+              "pLMNId_MNC": "55"
+            },
+            {
+              "gNBId": 11,
+              "txpower": 2,
+              "pLMNId_MCC": "466",
+              "cellLocalId": "00000100001000",
+              "pLMNId_MNC": "55"
+            },
+            {
+              "gNBId": 15,
+              "txpower": 2,
+              "pLMNId_MCC": "466",
+              "cellLocalId": "00000100001000",
+              "pLMNId_MNC": "55"
+            },
+            {
+              "gNBId": 5,
+              "txpower": 2,
+              "pLMNId_MCC": "466",
+              "cellLocalId": "00000100001000",
+              "pLMNId_MNC": "55"
+            },
+            {
+              "gNBId": 14,
+              "txpower": 2,
+              "pLMNId_MCC": "466",
+              "cellLocalId": "00000100001000",
+              "pLMNId_MNC": "55"
+            },
+            {
+              "gNBId": 12,
+              "txpower": 2,
+              "pLMNId_MCC": "466",
+              "cellLocalId": "00000100001000",
+              "pLMNId_MNC": "55"
+            },
+            {
+              "gNBId": 1,
+              "txpower": 2,
+              "pLMNId_MCC": "466",
+              "cellLocalId": "00000100001000",
+              "pLMNId_MNC": "55"
+            },
+            {
+              "gNBId": 17,
+              "txpower": 2,
+              "pLMNId_MCC": "466",
+              "cellLocalId": "00000100001000",
+              "pLMNId_MNC": "55"
+            },
+            {
+              "gNBId": 2,
+              "txpower": 2,
+              "pLMNId_MCC": "466",
+              "cellLocalId": "00000100001000",
+              "pLMNId_MNC": "55"
+            },
+            {
+              "gNBId": 10,
+              "txpower": 2,
+              "pLMNId_MCC": "466",
+              "cellLocalId": "00000100001000",
+              "pLMNId_MNC": "55"
+            },
+            {
+              "gNBId": 13,
+              "txpower": 2,
+              "pLMNId_MCC": "466",
+              "cellLocalId": "00000100001000",
+              "pLMNId_MNC": "55"
+            },
+            {
+              "gNBId": 8,
+              "txpower": 2,
+              "pLMNId_MCC": "466",
+              "cellLocalId": "00000100001000",
+              "pLMNId_MNC": "55"
+            }
+          ],
+          "average_sinr": "-5.902576",
+          "coverage": "0.520000"
+        },
+        "anr": {
+          "field": "e6700d701f8b41f8950e",
+          "cellIndividualResult": [
+            {
+              "gNBId": 16,
+              "cellLocalId": "00000100001000",
+              "NRCellRelation": [
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 11,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 154,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0"
+                },
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 12,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 141,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0"
+                },
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 10,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 157,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0"
+                },
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 13,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 144,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "nRFreqRelation": [
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    },
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    },
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    },
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    }
+                  ],
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0",
+                  "externalNrCellCu": []
+                }
+              ],
+              "pLMNId_MCC": "466",
+              "pLMNId_MNC": "55"
+            },
+            {
+              "gNBId": 6,
+              "cellLocalId": "00000100001000",
+              "NRCellRelation": [
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 5,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 142,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0"
+                },
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 17,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 143,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0"
+                },
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 2,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 148,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "nRFreqRelation": [
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    },
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    },
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    }
+                  ],
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0",
+                  "externalNrCellCu": []
+                }
+              ],
+              "pLMNId_MCC": "466",
+              "pLMNId_MNC": "55"
+            },
+            {
+              "gNBId": 11,
+              "cellLocalId": "00000100001000",
+              "NRCellRelation": [
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 16,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 153,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0"
+                },
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 10,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 157,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0"
+                },
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 13,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 144,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "nRFreqRelation": [
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    },
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    },
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    }
+                  ],
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0",
+                  "externalNrCellCu": []
+                }
+              ],
+              "pLMNId_MCC": "466",
+              "pLMNId_MNC": "55"
+            },
+            {
+              "gNBId": 15,
+              "cellLocalId": "00000100001000",
+              "NRCellRelation": [
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 14,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 156,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "nRFreqRelation": [
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    }
+                  ],
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0",
+                  "externalNrCellCu": []
+                }
+              ],
+              "pLMNId_MCC": "466",
+              "pLMNId_MNC": "55"
+            },
+            {
+              "gNBId": 5,
+              "cellLocalId": "00000100001000",
+              "NRCellRelation": [
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 6,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 140,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0"
+                },
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 8,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 145,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "nRFreqRelation": [
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    },
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    }
+                  ],
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0",
+                  "externalNrCellCu": []
+                }
+              ],
+              "pLMNId_MCC": "466",
+              "pLMNId_MNC": "55"
+            },
+            {
+              "gNBId": 14,
+              "cellLocalId": "00000100001000",
+              "NRCellRelation": [
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 15,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 160,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "nRFreqRelation": [
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    }
+                  ],
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0",
+                  "externalNrCellCu": []
+                }
+              ],
+              "pLMNId_MCC": "466",
+              "pLMNId_MNC": "55"
+            },
+            {
+              "gNBId": 12,
+              "cellLocalId": "00000100001000",
+              "NRCellRelation": [
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 16,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 153,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0"
+                },
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 10,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 157,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0"
+                },
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 13,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 144,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "nRFreqRelation": [
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    },
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    },
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    }
+                  ],
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0",
+                  "externalNrCellCu": []
+                }
+              ],
+              "pLMNId_MCC": "466",
+              "pLMNId_MNC": "55"
+            },
+            {
+              "gNBId": 1,
+              "cellLocalId": "00000100001000",
+              "NRCellRelation": [
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 17,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 143,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0"
+                },
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 2,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 148,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "nRFreqRelation": [
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    },
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    }
+                  ],
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0",
+                  "externalNrCellCu": []
+                }
+              ],
+              "pLMNId_MCC": "466",
+              "pLMNId_MNC": "55"
+            },
+            {
+              "gNBId": 17,
+              "cellLocalId": "00000100001000",
+              "NRCellRelation": [
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 6,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 140,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0"
+                },
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 1,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 139,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0"
+                },
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 2,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 148,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "nRFreqRelation": [
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    },
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    },
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    }
+                  ],
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0",
+                  "externalNrCellCu": []
+                }
+              ],
+              "pLMNId_MCC": "466",
+              "pLMNId_MNC": "55"
+            },
+            {
+              "gNBId": 2,
+              "cellLocalId": "00000100001000",
+              "NRCellRelation": [
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 6,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 140,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0"
+                },
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 1,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 139,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0"
+                },
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 17,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 143,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "nRFreqRelation": [
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    },
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    },
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    }
+                  ],
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0",
+                  "externalNrCellCu": []
+                }
+              ],
+              "pLMNId_MCC": "466",
+              "pLMNId_MNC": "55"
+            },
+            {
+              "gNBId": 10,
+              "cellLocalId": "00000100001000",
+              "NRCellRelation": [
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 16,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 153,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0"
+                },
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 11,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 154,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0"
+                },
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 12,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 141,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "nRFreqRelation": [
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    },
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    },
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    }
+                  ],
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0",
+                  "externalNrCellCu": []
+                }
+              ],
+              "pLMNId_MCC": "466",
+              "pLMNId_MNC": "55"
+            },
+            {
+              "gNBId": 13,
+              "cellLocalId": "00000100001000",
+              "NRCellRelation": [
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 16,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 153,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0"
+                },
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 11,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 154,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0"
+                },
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 12,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 141,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "nRFreqRelation": [
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    },
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    },
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    }
+                  ],
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0",
+                  "externalNrCellCu": []
+                }
+              ],
+              "pLMNId_MCC": "466",
+              "pLMNId_MNC": "55"
+            },
+            {
+              "gNBId": 8,
+              "cellLocalId": "00000100001000",
+              "NRCellRelation": [
+                {
+                  "cellIndividualOffset": {
+                    "sinrOffsetSsb": "db0",
+                    "rsrpOffsetSsb": "db0",
+                    "rsrqOffsetCsiRs": "db0",
+                    "rsrqOffsetSsb": "db0",
+                    "rsrpOffsetCsiRs": "db0",
+                    "sinrOffsetCsiRs": "db0"
+                  },
+                  "cellLocalId": "00000100001000",
+                  "gNBId": 5,
+                  "nRFrequencyRef": "id0",
+                  "nRPCI": 142,
+                  "isRemoveAllowed": "false",
+                  "arfcnDl": 4850,
+                  "nRFreqRelation": [
+                    {
+                      "qRxLevMin": -90,
+                      "threshXLowP": 0,
+                      "threshXHighP": 62,
+                      "nRFrequncyRef": "id0",
+                      "tReselectionNr": 0
+                    }
+                  ],
+                  "isHOAllowed": "true",
+                  "pLMNId_MNC": "55",
+                  "pLMNId_MCC": "466",
+                  "nRFreqRelationRef": "id0",
+                  "adjacentNrCellRef": "id0",
+                  "externalNrCellCu": []
+                }
+              ],
+              "pLMNId_MCC": "466",
+              "pLMNId_MNC": "55"
+            }
+          ]
+        },
+        "pci": {
+          "collision_cell": [],
+          "collision_count": [],
+          "collision_count_new": [
+            {
+              "collision_pci": 150,
+              "collision_count": 14
+            },
+            {
+              "collision_pci": 151,
+              "collision_count": 2
+            }
+          ],
+          "confusion_cell": [],
+          "confusion_count_new": [
+            {
+              "confusion_pci": 151,
+              "confusion_count": 2
+            },
+            {
+              "confusion_pci": 150,
+              "confusion_count": 22
+            }
+          ],
+          "confusion_count": [],
+          "confusion_cell_new": [
+            {
+              "confusion_pci": 151,
+              "confused_mnc": "55",
+              "source_gNBId": 11,
+              "source_gNBId_length": 22,
+              "confused_gNBId_length": 22,
+              "source_mcc": "466",
+              "confused_gNBId": 16,
+              "confused_cellLocalId": 264,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 13,
+              "confused_mcc": "466",
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "confusion_pci": 150,
+              "confused_mnc": "55",
+              "source_gNBId": 12,
+              "source_gNBId_length": 22,
+              "confused_gNBId_length": 22,
+              "source_mcc": "466",
+              "confused_gNBId": 16,
+              "confused_cellLocalId": 264,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 10,
+              "confused_mcc": "466",
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "confusion_pci": 150,
+              "confused_mnc": "55",
+              "source_gNBId": 10,
+              "source_gNBId_length": 22,
+              "confused_gNBId_length": 22,
+              "source_mcc": "466",
+              "confused_gNBId": 16,
+              "confused_cellLocalId": 264,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 12,
+              "confused_mcc": "466",
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "confusion_pci": 151,
+              "confused_mnc": "55",
+              "source_gNBId": 13,
+              "source_gNBId_length": 22,
+              "confused_gNBId_length": 22,
+              "source_mcc": "466",
+              "confused_gNBId": 16,
+              "confused_cellLocalId": 264,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 11,
+              "confused_mcc": "466",
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "confusion_pci": 150,
+              "confused_mnc": "55",
+              "source_gNBId": 5,
+              "source_gNBId_length": 22,
+              "confused_gNBId_length": 22,
+              "source_mcc": "466",
+              "confused_gNBId": 6,
+              "confused_cellLocalId": 264,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 2,
+              "confused_mcc": "466",
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "confusion_pci": 150,
+              "confused_mnc": "55",
+              "source_gNBId": 2,
+              "source_gNBId_length": 22,
+              "confused_gNBId_length": 22,
+              "source_mcc": "466",
+              "confused_gNBId": 6,
+              "confused_cellLocalId": 264,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 5,
+              "confused_mcc": "466",
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "confusion_pci": 150,
+              "confused_mnc": "55",
+              "source_gNBId": 16,
+              "source_gNBId_length": 22,
+              "confused_gNBId_length": 22,
+              "source_mcc": "466",
+              "confused_gNBId": 11,
+              "confused_cellLocalId": 264,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 10,
+              "confused_mcc": "466",
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "confusion_pci": 150,
+              "confused_mnc": "55",
+              "source_gNBId": 10,
+              "source_gNBId_length": 22,
+              "confused_gNBId_length": 22,
+              "source_mcc": "466",
+              "confused_gNBId": 11,
+              "confused_cellLocalId": 264,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 16,
+              "confused_mcc": "466",
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "confusion_pci": 150,
+              "confused_mnc": "55",
+              "source_gNBId": 6,
+              "source_gNBId_length": 22,
+              "confused_gNBId_length": 22,
+              "source_mcc": "466",
+              "confused_gNBId": 5,
+              "confused_cellLocalId": 264,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 8,
+              "confused_mcc": "466",
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "confusion_pci": 150,
+              "confused_mnc": "55",
+              "source_gNBId": 8,
+              "source_gNBId_length": 22,
+              "confused_gNBId_length": 22,
+              "source_mcc": "466",
+              "confused_gNBId": 5,
+              "confused_cellLocalId": 264,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 6,
+              "confused_mcc": "466",
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "confusion_pci": 150,
+              "confused_mnc": "55",
+              "source_gNBId": 16,
+              "source_gNBId_length": 22,
+              "confused_gNBId_length": 22,
+              "source_mcc": "466",
+              "confused_gNBId": 12,
+              "confused_cellLocalId": 264,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 10,
+              "confused_mcc": "466",
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "confusion_pci": 150,
+              "confused_mnc": "55",
+              "source_gNBId": 10,
+              "source_gNBId_length": 22,
+              "confused_gNBId_length": 22,
+              "source_mcc": "466",
+              "confused_gNBId": 12,
+              "confused_cellLocalId": 264,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 16,
+              "confused_mcc": "466",
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "confusion_pci": 150,
+              "confused_mnc": "55",
+              "source_gNBId": 6,
+              "source_gNBId_length": 22,
+              "confused_gNBId_length": 22,
+              "source_mcc": "466",
+              "confused_gNBId": 17,
+              "confused_cellLocalId": 264,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 1,
+              "confused_mcc": "466",
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "confusion_pci": 150,
+              "confused_mnc": "55",
+              "source_gNBId": 6,
+              "source_gNBId_length": 22,
+              "confused_gNBId_length": 22,
+              "source_mcc": "466",
+              "confused_gNBId": 17,
+              "confused_cellLocalId": 264,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 2,
+              "confused_mcc": "466",
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "confusion_pci": 150,
+              "confused_mnc": "55",
+              "source_gNBId": 1,
+              "source_gNBId_length": 22,
+              "confused_gNBId_length": 22,
+              "source_mcc": "466",
+              "confused_gNBId": 17,
+              "confused_cellLocalId": 264,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 6,
+              "confused_mcc": "466",
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "confusion_pci": 150,
+              "confused_mnc": "55",
+              "source_gNBId": 1,
+              "source_gNBId_length": 22,
+              "confused_gNBId_length": 22,
+              "source_mcc": "466",
+              "confused_gNBId": 17,
+              "confused_cellLocalId": 264,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 2,
+              "confused_mcc": "466",
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "confusion_pci": 150,
+              "confused_mnc": "55",
+              "source_gNBId": 2,
+              "source_gNBId_length": 22,
+              "confused_gNBId_length": 22,
+              "source_mcc": "466",
+              "confused_gNBId": 17,
+              "confused_cellLocalId": 264,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 6,
+              "confused_mcc": "466",
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "confusion_pci": 150,
+              "confused_mnc": "55",
+              "source_gNBId": 2,
+              "source_gNBId_length": 22,
+              "confused_gNBId_length": 22,
+              "source_mcc": "466",
+              "confused_gNBId": 17,
+              "confused_cellLocalId": 264,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 1,
+              "confused_mcc": "466",
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "confusion_pci": 150,
+              "confused_mnc": "55",
+              "source_gNBId": 6,
+              "source_gNBId_length": 22,
+              "confused_gNBId_length": 22,
+              "source_mcc": "466",
+              "confused_gNBId": 2,
+              "confused_cellLocalId": 264,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 1,
+              "confused_mcc": "466",
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "confusion_pci": 150,
+              "confused_mnc": "55",
+              "source_gNBId": 1,
+              "source_gNBId_length": 22,
+              "confused_gNBId_length": 22,
+              "source_mcc": "466",
+              "confused_gNBId": 2,
+              "confused_cellLocalId": 264,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 6,
+              "confused_mcc": "466",
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "confusion_pci": 150,
+              "confused_mnc": "55",
+              "source_gNBId": 16,
+              "source_gNBId_length": 22,
+              "confused_gNBId_length": 22,
+              "source_mcc": "466",
+              "confused_gNBId": 10,
+              "confused_cellLocalId": 264,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 12,
+              "confused_mcc": "466",
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "confusion_pci": 150,
+              "confused_mnc": "55",
+              "source_gNBId": 12,
+              "source_gNBId_length": 22,
+              "confused_gNBId_length": 22,
+              "source_mcc": "466",
+              "confused_gNBId": 10,
+              "confused_cellLocalId": 264,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 16,
+              "confused_mcc": "466",
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "confusion_pci": 150,
+              "confused_mnc": "55",
+              "source_gNBId": 16,
+              "source_gNBId_length": 22,
+              "confused_gNBId_length": 22,
+              "source_mcc": "466",
+              "confused_gNBId": 13,
+              "confused_cellLocalId": 264,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 12,
+              "confused_mcc": "466",
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "confusion_pci": 150,
+              "confused_mnc": "55",
+              "source_gNBId": 12,
+              "source_gNBId_length": 22,
+              "confused_gNBId_length": 22,
+              "source_mcc": "466",
+              "confused_gNBId": 13,
+              "confused_cellLocalId": 264,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 16,
+              "confused_mcc": "466",
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            }
+          ],
+          "collision_cell_new": [
+            {
+              "collision_pci": 150,
+              "source_gNBId": 16,
+              "source_mcc": "466",
+              "source_gNBId_length": 22,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 12,
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "collision_pci": 150,
+              "source_gNBId": 16,
+              "source_mcc": "466",
+              "source_gNBId_length": 22,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 10,
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "collision_pci": 150,
+              "source_gNBId": 6,
+              "source_mcc": "466",
+              "source_gNBId_length": 22,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 5,
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "collision_pci": 150,
+              "source_gNBId": 6,
+              "source_mcc": "466",
+              "source_gNBId_length": 22,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 2,
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "collision_pci": 151,
+              "source_gNBId": 11,
+              "source_mcc": "466",
+              "source_gNBId_length": 22,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 13,
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "collision_pci": 150,
+              "source_gNBId": 5,
+              "source_mcc": "466",
+              "source_gNBId_length": 22,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 6,
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "collision_pci": 150,
+              "source_gNBId": 5,
+              "source_mcc": "466",
+              "source_gNBId_length": 22,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 8,
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "collision_pci": 150,
+              "source_gNBId": 12,
+              "source_mcc": "466",
+              "source_gNBId_length": 22,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 16,
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "collision_pci": 150,
+              "source_gNBId": 12,
+              "source_mcc": "466",
+              "source_gNBId_length": 22,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 10,
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "collision_pci": 150,
+              "source_gNBId": 1,
+              "source_mcc": "466",
+              "source_gNBId_length": 22,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 2,
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "collision_pci": 150,
+              "source_gNBId": 2,
+              "source_mcc": "466",
+              "source_gNBId_length": 22,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 6,
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "collision_pci": 150,
+              "source_gNBId": 2,
+              "source_mcc": "466",
+              "source_gNBId_length": 22,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 1,
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "collision_pci": 150,
+              "source_gNBId": 10,
+              "source_mcc": "466",
+              "source_gNBId_length": 22,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 16,
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "collision_pci": 150,
+              "source_gNBId": 10,
+              "source_mcc": "466",
+              "source_gNBId_length": 22,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 12,
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "collision_pci": 151,
+              "source_gNBId": 13,
+              "source_mcc": "466",
+              "source_gNBId_length": 22,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 11,
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            },
+            {
+              "collision_pci": 150,
+              "source_gNBId": 8,
+              "source_mcc": "466",
+              "source_gNBId_length": 22,
+              "source_cellLocalId": 264,
+              "target_cellLocalId": 264,
+              "source_mnc": "55",
+              "target_gNBId": 5,
+              "target_gNBId_length": 22,
+              "target_mcc": "466",
+              "target_mnc": "55"
+            }
+          ],
+          "cellIndividualResult": [
+            {
+              "nrPCI": 150,
+              "NRCellRelation": [
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 151,
+                  "gNBId": 11,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 151,
+                  "PLMNId_MNC": "55"
+                },
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 150,
+                  "gNBId": 12,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 150,
+                  "PLMNId_MNC": "55"
+                },
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 150,
+                  "gNBId": 10,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 150,
+                  "PLMNId_MNC": "55"
+                },
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 151,
+                  "gNBId": 13,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 151,
+                  "PLMNId_MNC": "55"
+                }
+              ],
+              "gNBId": 16,
+              "cellLocalId": "00000100001000",
+              "PLMNId_MCC": "466",
+              "PLMNId_MNC": "55"
+            },
+            {
+              "nrPCI": 150,
+              "NRCellRelation": [
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 150,
+                  "gNBId": 5,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 150,
+                  "PLMNId_MNC": "55"
+                },
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 151,
+                  "gNBId": 17,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 151,
+                  "PLMNId_MNC": "55"
+                },
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 150,
+                  "gNBId": 2,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 150,
+                  "PLMNId_MNC": "55"
+                }
+              ],
+              "gNBId": 6,
+              "cellLocalId": "00000100001000",
+              "PLMNId_MCC": "466",
+              "PLMNId_MNC": "55"
+            },
+            {
+              "nrPCI": 151,
+              "NRCellRelation": [
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 150,
+                  "gNBId": 16,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 150,
+                  "PLMNId_MNC": "55"
+                },
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 150,
+                  "gNBId": 10,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 150,
+                  "PLMNId_MNC": "55"
+                },
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 151,
+                  "gNBId": 13,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 151,
+                  "PLMNId_MNC": "55"
+                }
+              ],
+              "gNBId": 11,
+              "cellLocalId": "00000100001000",
+              "PLMNId_MCC": "466",
+              "PLMNId_MNC": "55"
+            },
+            {
+              "nrPCI": 151,
+              "NRCellRelation": [
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 150,
+                  "gNBId": 14,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 150,
+                  "PLMNId_MNC": "55"
+                }
+              ],
+              "gNBId": 15,
+              "cellLocalId": "00000100001000",
+              "PLMNId_MCC": "466",
+              "PLMNId_MNC": "55"
+            },
+            {
+              "nrPCI": 150,
+              "NRCellRelation": [
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 150,
+                  "gNBId": 6,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 150,
+                  "PLMNId_MNC": "55"
+                },
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 150,
+                  "gNBId": 8,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 150,
+                  "PLMNId_MNC": "55"
+                }
+              ],
+              "gNBId": 5,
+              "cellLocalId": "00000100001000",
+              "PLMNId_MCC": "466",
+              "PLMNId_MNC": "55"
+            },
+            {
+              "nrPCI": 150,
+              "NRCellRelation": [
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 151,
+                  "gNBId": 15,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 151,
+                  "PLMNId_MNC": "55"
+                }
+              ],
+              "gNBId": 14,
+              "cellLocalId": "00000100001000",
+              "PLMNId_MCC": "466",
+              "PLMNId_MNC": "55"
+            },
+            {
+              "nrPCI": 150,
+              "NRCellRelation": [
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 150,
+                  "gNBId": 16,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 150,
+                  "PLMNId_MNC": "55"
+                },
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 150,
+                  "gNBId": 10,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 150,
+                  "PLMNId_MNC": "55"
+                },
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 151,
+                  "gNBId": 13,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 151,
+                  "PLMNId_MNC": "55"
+                }
+              ],
+              "gNBId": 12,
+              "cellLocalId": "00000100001000",
+              "PLMNId_MCC": "466",
+              "PLMNId_MNC": "55"
+            },
+            {
+              "nrPCI": 150,
+              "NRCellRelation": [
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 151,
+                  "gNBId": 17,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 151,
+                  "PLMNId_MNC": "55"
+                },
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 150,
+                  "gNBId": 2,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 150,
+                  "PLMNId_MNC": "55"
+                }
+              ],
+              "gNBId": 1,
+              "cellLocalId": "00000100001000",
+              "PLMNId_MCC": "466",
+              "PLMNId_MNC": "55"
+            },
+            {
+              "nrPCI": 151,
+              "NRCellRelation": [
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 150,
+                  "gNBId": 6,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 150,
+                  "PLMNId_MNC": "55"
+                },
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 150,
+                  "gNBId": 1,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 150,
+                  "PLMNId_MNC": "55"
+                },
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 150,
+                  "gNBId": 2,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 150,
+                  "PLMNId_MNC": "55"
+                }
+              ],
+              "gNBId": 17,
+              "cellLocalId": "00000100001000",
+              "PLMNId_MCC": "466",
+              "PLMNId_MNC": "55"
+            },
+            {
+              "nrPCI": 150,
+              "NRCellRelation": [
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 150,
+                  "gNBId": 6,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 150,
+                  "PLMNId_MNC": "55"
+                },
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 150,
+                  "gNBId": 1,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 150,
+                  "PLMNId_MNC": "55"
+                },
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 151,
+                  "gNBId": 17,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 151,
+                  "PLMNId_MNC": "55"
+                }
+              ],
+              "gNBId": 2,
+              "cellLocalId": "00000100001000",
+              "PLMNId_MCC": "466",
+              "PLMNId_MNC": "55"
+            },
+            {
+              "nrPCI": 150,
+              "NRCellRelation": [
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 150,
+                  "gNBId": 16,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 150,
+                  "PLMNId_MNC": "55"
+                },
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 151,
+                  "gNBId": 11,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 151,
+                  "PLMNId_MNC": "55"
+                },
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 150,
+                  "gNBId": 12,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 150,
+                  "PLMNId_MNC": "55"
+                }
+              ],
+              "gNBId": 10,
+              "cellLocalId": "00000100001000",
+              "PLMNId_MCC": "466",
+              "PLMNId_MNC": "55"
+            },
+            {
+              "nrPCI": 151,
+              "NRCellRelation": [
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 150,
+                  "gNBId": 16,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 150,
+                  "PLMNId_MNC": "55"
+                },
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 151,
+                  "gNBId": 11,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 151,
+                  "PLMNId_MNC": "55"
+                },
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 150,
+                  "gNBId": 12,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 150,
+                  "PLMNId_MNC": "55"
+                }
+              ],
+              "gNBId": 13,
+              "cellLocalId": "00000100001000",
+              "PLMNId_MCC": "466",
+              "PLMNId_MNC": "55"
+            },
+            {
+              "nrPCI": 150,
+              "NRCellRelation": [
+                {
+                  "cellLocalId": "00000100001000",
+                  "nRTCI": 150,
+                  "gNBId": 5,
+                  "PLMNId_MCC": "466",
+                  "nRPCI": 150,
+                  "PLMNId_MNC": "55"
+                }
+              ],
+              "gNBId": 8,
+              "cellLocalId": "00000100001000",
+              "PLMNId_MCC": "466",
+              "PLMNId_MNC": "55"
+            }
+          ]
+        }
+      };
+    */
+    
+    // 原鄰居基站多、新鄰居基站也多的狀況 04/12 Add 
     calculateSonResponse_local: ForCalculateSonResponse = {
       "cco": {
-        "field": "e6700d701f8b41f8950e",
+        "average_sinr": "-4.752979",
         "cellIndividualResult": [
           {
+            "txpower": 10,
             "gNBId": 16,
-            "txpower": 2,
             "pLMNId_MCC": "466",
             "cellLocalId": "00000100001000",
             "pLMNId_MNC": "55"
           },
           {
+            "txpower": 10,
             "gNBId": 6,
-            "txpower": 2,
             "pLMNId_MCC": "466",
             "cellLocalId": "00000100001000",
             "pLMNId_MNC": "55"
           },
           {
+            "txpower": 10,
             "gNBId": 11,
-            "txpower": 2,
             "pLMNId_MCC": "466",
             "cellLocalId": "00000100001000",
             "pLMNId_MNC": "55"
           },
           {
+            "txpower": 10,
             "gNBId": 15,
-            "txpower": 2,
             "pLMNId_MCC": "466",
             "cellLocalId": "00000100001000",
             "pLMNId_MNC": "55"
           },
           {
+            "txpower": 10,
             "gNBId": 5,
-            "txpower": 2,
             "pLMNId_MCC": "466",
             "cellLocalId": "00000100001000",
             "pLMNId_MNC": "55"
           },
           {
+            "txpower": 10,
             "gNBId": 14,
-            "txpower": 2,
             "pLMNId_MCC": "466",
             "cellLocalId": "00000100001000",
             "pLMNId_MNC": "55"
           },
           {
+            "txpower": 10,
             "gNBId": 12,
-            "txpower": 2,
             "pLMNId_MCC": "466",
             "cellLocalId": "00000100001000",
             "pLMNId_MNC": "55"
           },
           {
+            "txpower": 10,
             "gNBId": 1,
-            "txpower": 2,
             "pLMNId_MCC": "466",
             "cellLocalId": "00000100001000",
             "pLMNId_MNC": "55"
           },
           {
+            "txpower": 10,
             "gNBId": 17,
-            "txpower": 2,
             "pLMNId_MCC": "466",
             "cellLocalId": "00000100001000",
             "pLMNId_MNC": "55"
           },
           {
+            "txpower": 10,
             "gNBId": 2,
-            "txpower": 2,
             "pLMNId_MCC": "466",
             "cellLocalId": "00000100001000",
             "pLMNId_MNC": "55"
           },
           {
+            "txpower": 10,
             "gNBId": 10,
-            "txpower": 2,
             "pLMNId_MCC": "466",
             "cellLocalId": "00000100001000",
             "pLMNId_MNC": "55"
           },
           {
+            "txpower": 10,
             "gNBId": 13,
-            "txpower": 2,
             "pLMNId_MCC": "466",
             "cellLocalId": "00000100001000",
             "pLMNId_MNC": "55"
           },
           {
+            "txpower": 10,
             "gNBId": 8,
-            "txpower": 2,
             "pLMNId_MCC": "466",
             "cellLocalId": "00000100001000",
             "pLMNId_MNC": "55"
           }
         ],
-        "average_sinr": "-5.902576",
-        "coverage": "0.520000"
+        "field": "e6700d701f8b41f8950e",
+        "coverage": "0.430000"
       },
       "anr": {
         "field": "e6700d701f8b41f8950e",
@@ -111,2089 +2306,2940 @@
           {
             "gNBId": 16,
             "cellLocalId": "00000100001000",
+            "pLMNId_MCC": "466",
+            "pLMNId_MNC": "55",
             "NRCellRelation": [
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
-                "cellLocalId": "00000100001000",
                 "gNBId": 11,
-                "nRFrequencyRef": "id0",
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
                 "nRPCI": 154,
-                "isRemoveAllowed": "false",
-                "arfcnDl": 4850,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
                 "isHOAllowed": "true",
                 "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
+                "arfcnDl": 4850,
                 "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0"
+                "nRFrequencyRef": "id0"
               },
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
+                "gNBId": 15,
+                "isRemoveAllowed": "false",
                 "cellLocalId": "00000100001000",
+                "nRPCI": 160,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 5,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 142,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 14,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 156,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
                 "gNBId": 12,
-                "nRFrequencyRef": "id0",
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
                 "nRPCI": 141,
-                "isRemoveAllowed": "false",
-                "arfcnDl": 4850,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
                 "isHOAllowed": "true",
                 "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
+                "arfcnDl": 4850,
                 "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0"
+                "nRFrequencyRef": "id0"
               },
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
-                "cellLocalId": "00000100001000",
                 "gNBId": 10,
-                "nRFrequencyRef": "id0",
-                "nRPCI": 157,
                 "isRemoveAllowed": "false",
-                "arfcnDl": 4850,
+                "cellLocalId": "00000100001000",
+                "nRPCI": 157,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
                 "isHOAllowed": "true",
                 "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
+                "arfcnDl": 4850,
                 "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0"
+                "nRFrequencyRef": "id0"
               },
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
-                "cellLocalId": "00000100001000",
                 "gNBId": 13,
-                "nRFrequencyRef": "id0",
-                "nRPCI": 144,
                 "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 144,
+                "externalNrCellCu": [],
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
                 "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0",
                 "nRFreqRelation": [
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
-                    "nRFrequncyRef": "id0",
                     "tReselectionNr": 0
                   },
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
-                    "nRFrequncyRef": "id0",
                     "tReselectionNr": 0
                   },
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
-                    "nRFrequncyRef": "id0",
                     "tReselectionNr": 0
                   },
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
                     "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
                     "tReselectionNr": 0
                   }
-                ],
-                "isHOAllowed": "true",
-                "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
-                "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0",
-                "externalNrCellCu": []
+                ]
               }
-            ],
-            "pLMNId_MCC": "466",
-            "pLMNId_MNC": "55"
+            ]
           },
           {
             "gNBId": 6,
             "cellLocalId": "00000100001000",
+            "pLMNId_MCC": "466",
+            "pLMNId_MNC": "55",
             "NRCellRelation": [
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
-                "cellLocalId": "00000100001000",
                 "gNBId": 5,
-                "nRFrequencyRef": "id0",
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
                 "nRPCI": 142,
-                "isRemoveAllowed": "false",
-                "arfcnDl": 4850,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
                 "isHOAllowed": "true",
                 "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
+                "arfcnDl": 4850,
                 "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0"
+                "nRFrequencyRef": "id0"
               },
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
+                "gNBId": 12,
+                "isRemoveAllowed": "false",
                 "cellLocalId": "00000100001000",
+                "nRPCI": 141,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 1,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 139,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
                 "gNBId": 17,
-                "nRFrequencyRef": "id0",
-                "nRPCI": 143,
                 "isRemoveAllowed": "false",
-                "arfcnDl": 4850,
+                "cellLocalId": "00000100001000",
+                "nRPCI": 143,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
                 "isHOAllowed": "true",
                 "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
+                "arfcnDl": 4850,
                 "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0"
+                "nRFrequencyRef": "id0"
               },
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
-                "cellLocalId": "00000100001000",
                 "gNBId": 2,
-                "nRFrequencyRef": "id0",
-                "nRPCI": 148,
                 "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 148,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
                 "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 10,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 157,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 8,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 145,
+                "externalNrCellCu": [],
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0",
                 "nRFreqRelation": [
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
-                    "nRFrequncyRef": "id0",
                     "tReselectionNr": 0
                   },
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
-                    "nRFrequncyRef": "id0",
                     "tReselectionNr": 0
                   },
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
                     "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
                     "tReselectionNr": 0
                   }
-                ],
-                "isHOAllowed": "true",
-                "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
-                "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0",
-                "externalNrCellCu": []
+                ]
               }
-            ],
-            "pLMNId_MCC": "466",
-            "pLMNId_MNC": "55"
+            ]
           },
           {
             "gNBId": 11,
             "cellLocalId": "00000100001000",
+            "pLMNId_MCC": "466",
+            "pLMNId_MNC": "55",
             "NRCellRelation": [
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
-                "cellLocalId": "00000100001000",
                 "gNBId": 16,
-                "nRFrequencyRef": "id0",
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
                 "nRPCI": 153,
-                "isRemoveAllowed": "false",
-                "arfcnDl": 4850,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
                 "isHOAllowed": "true",
                 "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
+                "arfcnDl": 4850,
                 "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0"
+                "nRFrequencyRef": "id0"
               },
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
+                "gNBId": 15,
+                "isRemoveAllowed": "false",
                 "cellLocalId": "00000100001000",
+                "nRPCI": 160,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 14,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 156,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 12,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 141,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
                 "gNBId": 10,
-                "nRFrequencyRef": "id0",
-                "nRPCI": 157,
                 "isRemoveAllowed": "false",
-                "arfcnDl": 4850,
+                "cellLocalId": "00000100001000",
+                "nRPCI": 157,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
                 "isHOAllowed": "true",
                 "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
+                "arfcnDl": 4850,
                 "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0"
+                "nRFrequencyRef": "id0"
               },
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
-                "cellLocalId": "00000100001000",
                 "gNBId": 13,
-                "nRFrequencyRef": "id0",
-                "nRPCI": 144,
                 "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 144,
+                "externalNrCellCu": [],
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
                 "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0",
                 "nRFreqRelation": [
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
-                    "nRFrequncyRef": "id0",
                     "tReselectionNr": 0
                   },
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
-                    "nRFrequncyRef": "id0",
                     "tReselectionNr": 0
                   },
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
                     "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
                     "tReselectionNr": 0
                   }
-                ],
-                "isHOAllowed": "true",
-                "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
-                "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0",
-                "externalNrCellCu": []
+                ]
               }
-            ],
-            "pLMNId_MCC": "466",
-            "pLMNId_MNC": "55"
+            ]
           },
           {
             "gNBId": 15,
             "cellLocalId": "00000100001000",
+            "pLMNId_MCC": "466",
+            "pLMNId_MNC": "55",
             "NRCellRelation": [
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
-                "cellLocalId": "00000100001000",
-                "gNBId": 14,
-                "nRFrequencyRef": "id0",
-                "nRPCI": 156,
+                "gNBId": 16,
                 "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 153,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
                 "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 11,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 154,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 14,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 156,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 13,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 144,
+                "externalNrCellCu": [],
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0",
                 "nRFreqRelation": [
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
                     "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
                     "tReselectionNr": 0
                   }
-                ],
-                "isHOAllowed": "true",
-                "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
-                "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0",
-                "externalNrCellCu": []
+                ]
               }
-            ],
-            "pLMNId_MCC": "466",
-            "pLMNId_MNC": "55"
+            ]
           },
           {
             "gNBId": 5,
             "cellLocalId": "00000100001000",
+            "pLMNId_MCC": "466",
+            "pLMNId_MNC": "55",
             "NRCellRelation": [
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
-                "cellLocalId": "00000100001000",
-                "gNBId": 6,
-                "nRFrequencyRef": "id0",
-                "nRPCI": 140,
+                "gNBId": 16,
                 "isRemoveAllowed": "false",
-                "arfcnDl": 4850,
+                "cellLocalId": "00000100001000",
+                "nRPCI": 153,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
                 "isHOAllowed": "true",
                 "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
+                "arfcnDl": 4850,
                 "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0"
+                "nRFrequencyRef": "id0"
               },
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
-                "cellLocalId": "00000100001000",
-                "gNBId": 8,
-                "nRFrequencyRef": "id0",
-                "nRPCI": 145,
+                "gNBId": 6,
                 "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 140,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
                 "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 12,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 141,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 1,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 139,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 17,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 143,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 2,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 148,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 10,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 157,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 8,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 145,
+                "externalNrCellCu": [],
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0",
                 "nRFreqRelation": [
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
-                    "nRFrequncyRef": "id0",
                     "tReselectionNr": 0
                   },
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
                     "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
                     "tReselectionNr": 0
                   }
-                ],
-                "isHOAllowed": "true",
-                "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
-                "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0",
-                "externalNrCellCu": []
+                ]
               }
-            ],
-            "pLMNId_MCC": "466",
-            "pLMNId_MNC": "55"
+            ]
           },
           {
             "gNBId": 14,
             "cellLocalId": "00000100001000",
+            "pLMNId_MCC": "466",
+            "pLMNId_MNC": "55",
             "NRCellRelation": [
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
-                "cellLocalId": "00000100001000",
-                "gNBId": 15,
-                "nRFrequencyRef": "id0",
-                "nRPCI": 160,
+                "gNBId": 16,
                 "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 153,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
                 "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 11,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 154,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 15,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 160,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 13,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 144,
+                "externalNrCellCu": [],
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0",
                 "nRFreqRelation": [
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
                     "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
                     "tReselectionNr": 0
                   }
-                ],
-                "isHOAllowed": "true",
-                "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
-                "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0",
-                "externalNrCellCu": []
+                ]
               }
-            ],
-            "pLMNId_MCC": "466",
-            "pLMNId_MNC": "55"
+            ]
           },
           {
             "gNBId": 12,
             "cellLocalId": "00000100001000",
+            "pLMNId_MCC": "466",
+            "pLMNId_MNC": "55",
             "NRCellRelation": [
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
-                "cellLocalId": "00000100001000",
                 "gNBId": 16,
-                "nRFrequencyRef": "id0",
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
                 "nRPCI": 153,
-                "isRemoveAllowed": "false",
-                "arfcnDl": 4850,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
                 "isHOAllowed": "true",
                 "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
+                "arfcnDl": 4850,
                 "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0"
+                "nRFrequencyRef": "id0"
               },
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
+                "gNBId": 6,
+                "isRemoveAllowed": "false",
                 "cellLocalId": "00000100001000",
+                "nRPCI": 140,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 11,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 154,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 5,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 142,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
                 "gNBId": 10,
-                "nRFrequencyRef": "id0",
-                "nRPCI": 157,
                 "isRemoveAllowed": "false",
-                "arfcnDl": 4850,
+                "cellLocalId": "00000100001000",
+                "nRPCI": 157,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
                 "isHOAllowed": "true",
                 "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
+                "arfcnDl": 4850,
                 "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0"
+                "nRFrequencyRef": "id0"
               },
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
-                "cellLocalId": "00000100001000",
                 "gNBId": 13,
-                "nRFrequencyRef": "id0",
-                "nRPCI": 144,
                 "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 144,
+                "externalNrCellCu": [],
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
                 "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0",
                 "nRFreqRelation": [
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
-                    "nRFrequncyRef": "id0",
                     "tReselectionNr": 0
                   },
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
-                    "nRFrequncyRef": "id0",
                     "tReselectionNr": 0
                   },
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
                     "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
                     "tReselectionNr": 0
                   }
-                ],
-                "isHOAllowed": "true",
-                "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
-                "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0",
-                "externalNrCellCu": []
+                ]
               }
-            ],
-            "pLMNId_MCC": "466",
-            "pLMNId_MNC": "55"
+            ]
           },
           {
             "gNBId": 1,
             "cellLocalId": "00000100001000",
+            "pLMNId_MCC": "466",
+            "pLMNId_MNC": "55",
             "NRCellRelation": [
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
-                "cellLocalId": "00000100001000",
-                "gNBId": 17,
-                "nRFrequencyRef": "id0",
-                "nRPCI": 143,
+                "gNBId": 6,
                 "isRemoveAllowed": "false",
-                "arfcnDl": 4850,
+                "cellLocalId": "00000100001000",
+                "nRPCI": 140,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
                 "isHOAllowed": "true",
                 "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
+                "arfcnDl": 4850,
                 "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0"
+                "nRFrequencyRef": "id0"
               },
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
-                "cellLocalId": "00000100001000",
-                "gNBId": 2,
-                "nRFrequencyRef": "id0",
-                "nRPCI": 148,
+                "gNBId": 5,
                 "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 142,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
                 "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 17,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 143,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 2,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 148,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 8,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 145,
+                "externalNrCellCu": [],
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0",
                 "nRFreqRelation": [
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
-                    "nRFrequncyRef": "id0",
                     "tReselectionNr": 0
                   },
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
                     "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
                     "tReselectionNr": 0
                   }
-                ],
-                "isHOAllowed": "true",
-                "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
-                "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0",
-                "externalNrCellCu": []
+                ]
               }
-            ],
-            "pLMNId_MCC": "466",
-            "pLMNId_MNC": "55"
+            ]
           },
           {
             "gNBId": 17,
             "cellLocalId": "00000100001000",
+            "pLMNId_MCC": "466",
+            "pLMNId_MNC": "55",
             "NRCellRelation": [
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
-                "cellLocalId": "00000100001000",
                 "gNBId": 6,
-                "nRFrequencyRef": "id0",
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
                 "nRPCI": 140,
-                "isRemoveAllowed": "false",
-                "arfcnDl": 4850,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
                 "isHOAllowed": "true",
                 "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
+                "arfcnDl": 4850,
                 "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0"
+                "nRFrequencyRef": "id0"
               },
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
+                "gNBId": 5,
+                "isRemoveAllowed": "false",
                 "cellLocalId": "00000100001000",
+                "nRPCI": 142,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
                 "gNBId": 1,
-                "nRFrequencyRef": "id0",
-                "nRPCI": 139,
                 "isRemoveAllowed": "false",
-                "arfcnDl": 4850,
+                "cellLocalId": "00000100001000",
+                "nRPCI": 139,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
                 "isHOAllowed": "true",
                 "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
+                "arfcnDl": 4850,
                 "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0"
+                "nRFrequencyRef": "id0"
               },
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
-                "cellLocalId": "00000100001000",
                 "gNBId": 2,
-                "nRFrequencyRef": "id0",
-                "nRPCI": 148,
                 "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 148,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
                 "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 8,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 145,
+                "externalNrCellCu": [],
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0",
                 "nRFreqRelation": [
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
-                    "nRFrequncyRef": "id0",
                     "tReselectionNr": 0
                   },
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
-                    "nRFrequncyRef": "id0",
                     "tReselectionNr": 0
                   },
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
                     "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
                     "tReselectionNr": 0
                   }
-                ],
-                "isHOAllowed": "true",
-                "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
-                "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0",
-                "externalNrCellCu": []
+                ]
               }
-            ],
-            "pLMNId_MCC": "466",
-            "pLMNId_MNC": "55"
+            ]
           },
           {
             "gNBId": 2,
             "cellLocalId": "00000100001000",
+            "pLMNId_MCC": "466",
+            "pLMNId_MNC": "55",
             "NRCellRelation": [
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
-                "cellLocalId": "00000100001000",
                 "gNBId": 6,
-                "nRFrequencyRef": "id0",
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
                 "nRPCI": 140,
-                "isRemoveAllowed": "false",
-                "arfcnDl": 4850,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
                 "isHOAllowed": "true",
                 "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
+                "arfcnDl": 4850,
                 "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0"
+                "nRFrequencyRef": "id0"
               },
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
+                "gNBId": 5,
+                "isRemoveAllowed": "false",
                 "cellLocalId": "00000100001000",
+                "nRPCI": 142,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
                 "gNBId": 1,
-                "nRFrequencyRef": "id0",
-                "nRPCI": 139,
                 "isRemoveAllowed": "false",
-                "arfcnDl": 4850,
+                "cellLocalId": "00000100001000",
+                "nRPCI": 139,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
                 "isHOAllowed": "true",
                 "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
+                "arfcnDl": 4850,
                 "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0"
+                "nRFrequencyRef": "id0"
               },
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
-                "cellLocalId": "00000100001000",
                 "gNBId": 17,
-                "nRFrequencyRef": "id0",
-                "nRPCI": 143,
                 "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 143,
+                "externalNrCellCu": [],
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
                 "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0",
                 "nRFreqRelation": [
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
-                    "nRFrequncyRef": "id0",
                     "tReselectionNr": 0
                   },
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
-                    "nRFrequncyRef": "id0",
                     "tReselectionNr": 0
                   },
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
                     "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
                     "tReselectionNr": 0
                   }
-                ],
-                "isHOAllowed": "true",
-                "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
-                "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0",
-                "externalNrCellCu": []
+                ]
               }
-            ],
-            "pLMNId_MCC": "466",
-            "pLMNId_MNC": "55"
+            ]
           },
           {
             "gNBId": 10,
             "cellLocalId": "00000100001000",
+            "pLMNId_MCC": "466",
+            "pLMNId_MNC": "55",
             "NRCellRelation": [
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
-                "cellLocalId": "00000100001000",
                 "gNBId": 16,
-                "nRFrequencyRef": "id0",
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
                 "nRPCI": 153,
-                "isRemoveAllowed": "false",
-                "arfcnDl": 4850,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
                 "isHOAllowed": "true",
                 "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
+                "arfcnDl": 4850,
                 "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0"
+                "nRFrequencyRef": "id0"
               },
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
+                "gNBId": 6,
+                "isRemoveAllowed": "false",
                 "cellLocalId": "00000100001000",
+                "nRPCI": 140,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
                 "gNBId": 11,
-                "nRFrequencyRef": "id0",
-                "nRPCI": 154,
                 "isRemoveAllowed": "false",
-                "arfcnDl": 4850,
+                "cellLocalId": "00000100001000",
+                "nRPCI": 154,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
                 "isHOAllowed": "true",
                 "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
+                "arfcnDl": 4850,
                 "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0"
+                "nRFrequencyRef": "id0"
               },
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
-                "cellLocalId": "00000100001000",
-                "gNBId": 12,
-                "nRFrequencyRef": "id0",
-                "nRPCI": 141,
+                "gNBId": 5,
                 "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 142,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
                 "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 12,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 141,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 13,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 144,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 8,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 145,
+                "externalNrCellCu": [],
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0",
                 "nRFreqRelation": [
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
-                    "nRFrequncyRef": "id0",
                     "tReselectionNr": 0
                   },
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
-                    "nRFrequncyRef": "id0",
                     "tReselectionNr": 0
                   },
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
                     "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
                     "tReselectionNr": 0
                   }
-                ],
-                "isHOAllowed": "true",
-                "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
-                "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0",
-                "externalNrCellCu": []
+                ]
               }
-            ],
-            "pLMNId_MCC": "466",
-            "pLMNId_MNC": "55"
+            ]
           },
           {
             "gNBId": 13,
             "cellLocalId": "00000100001000",
+            "pLMNId_MCC": "466",
+            "pLMNId_MNC": "55",
             "NRCellRelation": [
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
-                "cellLocalId": "00000100001000",
                 "gNBId": 16,
-                "nRFrequencyRef": "id0",
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
                 "nRPCI": 153,
-                "isRemoveAllowed": "false",
-                "arfcnDl": 4850,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
                 "isHOAllowed": "true",
                 "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
+                "arfcnDl": 4850,
                 "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0"
+                "nRFrequencyRef": "id0"
               },
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
-                "cellLocalId": "00000100001000",
                 "gNBId": 11,
-                "nRFrequencyRef": "id0",
-                "nRPCI": 154,
                 "isRemoveAllowed": "false",
-                "arfcnDl": 4850,
+                "cellLocalId": "00000100001000",
+                "nRPCI": 154,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
                 "isHOAllowed": "true",
                 "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
+                "arfcnDl": 4850,
                 "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0"
+                "nRFrequencyRef": "id0"
               },
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
-                "cellLocalId": "00000100001000",
-                "gNBId": 12,
-                "nRFrequencyRef": "id0",
-                "nRPCI": 141,
+                "gNBId": 15,
                 "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 160,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
                 "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 14,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 156,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 12,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 141,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 10,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 157,
+                "externalNrCellCu": [],
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0",
                 "nRFreqRelation": [
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
-                    "nRFrequncyRef": "id0",
                     "tReselectionNr": 0
                   },
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
-                    "nRFrequncyRef": "id0",
                     "tReselectionNr": 0
                   },
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
                     "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
                     "tReselectionNr": 0
                   }
-                ],
-                "isHOAllowed": "true",
-                "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
-                "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0",
-                "externalNrCellCu": []
+                ]
               }
-            ],
-            "pLMNId_MCC": "466",
-            "pLMNId_MNC": "55"
+            ]
           },
           {
             "gNBId": 8,
             "cellLocalId": "00000100001000",
+            "pLMNId_MCC": "466",
+            "pLMNId_MNC": "55",
             "NRCellRelation": [
               {
                 "cellIndividualOffset": {
-                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetSsb": "db0",
-                  "rsrqOffsetCsiRs": "db0",
+                  "sinrOffsetCsiRs": "db0",
                   "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
                   "rsrpOffsetCsiRs": "db0",
-                  "sinrOffsetCsiRs": "db0"
+                  "rsrqOffsetCsiRs": "db0"
                 },
-                "cellLocalId": "00000100001000",
-                "gNBId": 5,
-                "nRFrequencyRef": "id0",
-                "nRPCI": 142,
+                "gNBId": 6,
                 "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 140,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
                 "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 5,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 142,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 1,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 139,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 17,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 143,
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0"
+              },
+              {
+                "cellIndividualOffset": {
+                  "rsrpOffsetSsb": "db0",
+                  "sinrOffsetCsiRs": "db0",
+                  "rsrqOffsetSsb": "db0",
+                  "sinrOffsetSsb": "db0",
+                  "rsrpOffsetCsiRs": "db0",
+                  "rsrqOffsetCsiRs": "db0"
+                },
+                "gNBId": 10,
+                "isRemoveAllowed": "false",
+                "cellLocalId": "00000100001000",
+                "nRPCI": 157,
+                "externalNrCellCu": [],
+                "pLMNId_MCC": "466",
+                "adjacentNrCellRef": "id0",
+                "isHOAllowed": "true",
+                "pLMNId_MNC": "55",
+                "arfcnDl": 4850,
+                "nRFreqRelationRef": "id0",
+                "nRFrequencyRef": "id0",
                 "nRFreqRelation": [
                   {
+                    "nRFrequncyRef": "id0",
                     "qRxLevMin": -90,
                     "threshXLowP": 0,
                     "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
                     "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
+                    "tReselectionNr": 0
+                  },
+                  {
+                    "nRFrequncyRef": "id0",
+                    "qRxLevMin": -90,
+                    "threshXLowP": 0,
+                    "threshXHighP": 62,
                     "tReselectionNr": 0
                   }
-                ],
-                "isHOAllowed": "true",
-                "pLMNId_MNC": "55",
-                "pLMNId_MCC": "466",
-                "nRFreqRelationRef": "id0",
-                "adjacentNrCellRef": "id0",
-                "externalNrCellCu": []
+                ]
               }
-            ],
-            "pLMNId_MCC": "466",
-            "pLMNId_MNC": "55"
+            ]
           }
         ]
       },
       "pci": {
         "collision_cell": [],
         "collision_count": [],
-        "collision_count_new": [
-          {
-            "collision_pci": 150,
-            "collision_count": 14
-          },
-          {
-            "collision_pci": 151,
-            "collision_count": 2
-          }
-        ],
+        "confusion_count_new": [],
+        "confusion_cell_new": [],
         "confusion_cell": [],
-        "confusion_count_new": [
+        "cellIndividualResult": [
           {
-            "confusion_pci": 151,
-            "confusion_count": 2
+            "nrPCI": 153,
+            "gNBId": 16,
+            "PLMNId_MCC": "466",
+            "cellLocalId": "00000100001000",
+            "PLMNId_MNC": "55",
+            "NRCellRelation": [
+              {
+                "nRTCI": 154,
+                "nRPCI": 154,
+                "gNBId": 11,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 160,
+                "nRPCI": 160,
+                "gNBId": 15,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 168,
+                "nRPCI": 168,
+                "gNBId": 5,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 156,
+                "nRPCI": 156,
+                "gNBId": 14,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 165,
+                "nRPCI": 165,
+                "gNBId": 12,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 157,
+                "nRPCI": 157,
+                "gNBId": 10,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 166,
+                "nRPCI": 166,
+                "gNBId": 13,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              }
+            ]
           },
           {
-            "confusion_pci": 150,
-            "confusion_count": 22
+            "nrPCI": 167,
+            "gNBId": 6,
+            "PLMNId_MCC": "466",
+            "cellLocalId": "00000100001000",
+            "PLMNId_MNC": "55",
+            "NRCellRelation": [
+              {
+                "nRTCI": 168,
+                "nRPCI": 168,
+                "gNBId": 5,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 165,
+                "nRPCI": 165,
+                "gNBId": 12,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 163,
+                "nRPCI": 163,
+                "gNBId": 1,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 166,
+                "nRPCI": 166,
+                "gNBId": 17,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 150,
+                "nRPCI": 150,
+                "gNBId": 2,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 157,
+                "nRPCI": 157,
+                "gNBId": 10,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 164,
+                "nRPCI": 164,
+                "gNBId": 8,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              }
+            ]
+          },
+          {
+            "nrPCI": 154,
+            "gNBId": 11,
+            "PLMNId_MCC": "466",
+            "cellLocalId": "00000100001000",
+            "PLMNId_MNC": "55",
+            "NRCellRelation": [
+              {
+                "nRTCI": 153,
+                "nRPCI": 153,
+                "gNBId": 16,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 160,
+                "nRPCI": 160,
+                "gNBId": 15,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 156,
+                "nRPCI": 156,
+                "gNBId": 14,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 165,
+                "nRPCI": 165,
+                "gNBId": 12,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 157,
+                "nRPCI": 157,
+                "gNBId": 10,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 166,
+                "nRPCI": 166,
+                "gNBId": 13,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              }
+            ]
+          },
+          {
+            "nrPCI": 160,
+            "gNBId": 15,
+            "PLMNId_MCC": "466",
+            "cellLocalId": "00000100001000",
+            "PLMNId_MNC": "55",
+            "NRCellRelation": [
+              {
+                "nRTCI": 153,
+                "nRPCI": 153,
+                "gNBId": 16,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 154,
+                "nRPCI": 154,
+                "gNBId": 11,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 156,
+                "nRPCI": 156,
+                "gNBId": 14,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 166,
+                "nRPCI": 166,
+                "gNBId": 13,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              }
+            ]
+          },
+          {
+            "nrPCI": 168,
+            "gNBId": 5,
+            "PLMNId_MCC": "466",
+            "cellLocalId": "00000100001000",
+            "PLMNId_MNC": "55",
+            "NRCellRelation": [
+              {
+                "nRTCI": 153,
+                "nRPCI": 153,
+                "gNBId": 16,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 167,
+                "nRPCI": 167,
+                "gNBId": 6,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 165,
+                "nRPCI": 165,
+                "gNBId": 12,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 163,
+                "nRPCI": 163,
+                "gNBId": 1,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 166,
+                "nRPCI": 166,
+                "gNBId": 17,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 150,
+                "nRPCI": 150,
+                "gNBId": 2,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 157,
+                "nRPCI": 157,
+                "gNBId": 10,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 164,
+                "nRPCI": 164,
+                "gNBId": 8,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              }
+            ]
+          },
+          {
+            "nrPCI": 156,
+            "gNBId": 14,
+            "PLMNId_MCC": "466",
+            "cellLocalId": "00000100001000",
+            "PLMNId_MNC": "55",
+            "NRCellRelation": [
+              {
+                "nRTCI": 153,
+                "nRPCI": 153,
+                "gNBId": 16,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 154,
+                "nRPCI": 154,
+                "gNBId": 11,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 160,
+                "nRPCI": 160,
+                "gNBId": 15,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 166,
+                "nRPCI": 166,
+                "gNBId": 13,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              }
+            ]
+          },
+          {
+            "nrPCI": 165,
+            "gNBId": 12,
+            "PLMNId_MCC": "466",
+            "cellLocalId": "00000100001000",
+            "PLMNId_MNC": "55",
+            "NRCellRelation": [
+              {
+                "nRTCI": 153,
+                "nRPCI": 153,
+                "gNBId": 16,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 167,
+                "nRPCI": 167,
+                "gNBId": 6,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 154,
+                "nRPCI": 154,
+                "gNBId": 11,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 168,
+                "nRPCI": 168,
+                "gNBId": 5,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 157,
+                "nRPCI": 157,
+                "gNBId": 10,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 166,
+                "nRPCI": 166,
+                "gNBId": 13,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              }
+            ]
+          },
+          {
+            "nrPCI": 163,
+            "gNBId": 1,
+            "PLMNId_MCC": "466",
+            "cellLocalId": "00000100001000",
+            "PLMNId_MNC": "55",
+            "NRCellRelation": [
+              {
+                "nRTCI": 167,
+                "nRPCI": 167,
+                "gNBId": 6,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 168,
+                "nRPCI": 168,
+                "gNBId": 5,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 166,
+                "nRPCI": 166,
+                "gNBId": 17,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 150,
+                "nRPCI": 150,
+                "gNBId": 2,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 164,
+                "nRPCI": 164,
+                "gNBId": 8,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              }
+            ]
+          },
+          {
+            "nrPCI": 166,
+            "gNBId": 17,
+            "PLMNId_MCC": "466",
+            "cellLocalId": "00000100001000",
+            "PLMNId_MNC": "55",
+            "NRCellRelation": [
+              {
+                "nRTCI": 167,
+                "nRPCI": 167,
+                "gNBId": 6,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 168,
+                "nRPCI": 168,
+                "gNBId": 5,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 163,
+                "nRPCI": 163,
+                "gNBId": 1,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 150,
+                "nRPCI": 150,
+                "gNBId": 2,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 164,
+                "nRPCI": 164,
+                "gNBId": 8,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              }
+            ]
+          },
+          {
+            "nrPCI": 150,
+            "gNBId": 2,
+            "PLMNId_MCC": "466",
+            "cellLocalId": "00000100001000",
+            "PLMNId_MNC": "55",
+            "NRCellRelation": [
+              {
+                "nRTCI": 167,
+                "nRPCI": 167,
+                "gNBId": 6,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 168,
+                "nRPCI": 168,
+                "gNBId": 5,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 163,
+                "nRPCI": 163,
+                "gNBId": 1,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 166,
+                "nRPCI": 166,
+                "gNBId": 17,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              }
+            ]
+          },
+          {
+            "nrPCI": 157,
+            "gNBId": 10,
+            "PLMNId_MCC": "466",
+            "cellLocalId": "00000100001000",
+            "PLMNId_MNC": "55",
+            "NRCellRelation": [
+              {
+                "nRTCI": 153,
+                "nRPCI": 153,
+                "gNBId": 16,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 167,
+                "nRPCI": 167,
+                "gNBId": 6,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 154,
+                "nRPCI": 154,
+                "gNBId": 11,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 168,
+                "nRPCI": 168,
+                "gNBId": 5,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 165,
+                "nRPCI": 165,
+                "gNBId": 12,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 166,
+                "nRPCI": 166,
+                "gNBId": 13,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 164,
+                "nRPCI": 164,
+                "gNBId": 8,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              }
+            ]
+          },
+          {
+            "nrPCI": 166,
+            "gNBId": 13,
+            "PLMNId_MCC": "466",
+            "cellLocalId": "00000100001000",
+            "PLMNId_MNC": "55",
+            "NRCellRelation": [
+              {
+                "nRTCI": 153,
+                "nRPCI": 153,
+                "gNBId": 16,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 154,
+                "nRPCI": 154,
+                "gNBId": 11,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 160,
+                "nRPCI": 160,
+                "gNBId": 15,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 156,
+                "nRPCI": 156,
+                "gNBId": 14,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 165,
+                "nRPCI": 165,
+                "gNBId": 12,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 157,
+                "nRPCI": 157,
+                "gNBId": 10,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              }
+            ]
+          },
+          {
+            "nrPCI": 164,
+            "gNBId": 8,
+            "PLMNId_MCC": "466",
+            "cellLocalId": "00000100001000",
+            "PLMNId_MNC": "55",
+            "NRCellRelation": [
+              {
+                "nRTCI": 167,
+                "nRPCI": 167,
+                "gNBId": 6,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 168,
+                "nRPCI": 168,
+                "gNBId": 5,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 163,
+                "nRPCI": 163,
+                "gNBId": 1,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 166,
+                "nRPCI": 166,
+                "gNBId": 17,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              },
+              {
+                "nRTCI": 157,
+                "nRPCI": 157,
+                "gNBId": 10,
+                "PLMNId_MCC": "466",
+                "cellLocalId": "00000100001000",
+                "PLMNId_MNC": "55"
+              }
+            ]
           }
         ],
         "confusion_count": [],
-        "confusion_cell_new": [
-          {
-            "confusion_pci": 151,
-            "confused_mnc": "55",
-            "source_gNBId": 11,
-            "source_gNBId_length": 22,
-            "confused_gNBId_length": 22,
-            "source_mcc": "466",
-            "confused_gNBId": 16,
-            "confused_cellLocalId": 264,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 13,
-            "confused_mcc": "466",
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "confusion_pci": 150,
-            "confused_mnc": "55",
-            "source_gNBId": 12,
-            "source_gNBId_length": 22,
-            "confused_gNBId_length": 22,
-            "source_mcc": "466",
-            "confused_gNBId": 16,
-            "confused_cellLocalId": 264,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 10,
-            "confused_mcc": "466",
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "confusion_pci": 150,
-            "confused_mnc": "55",
-            "source_gNBId": 10,
-            "source_gNBId_length": 22,
-            "confused_gNBId_length": 22,
-            "source_mcc": "466",
-            "confused_gNBId": 16,
-            "confused_cellLocalId": 264,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 12,
-            "confused_mcc": "466",
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "confusion_pci": 151,
-            "confused_mnc": "55",
-            "source_gNBId": 13,
-            "source_gNBId_length": 22,
-            "confused_gNBId_length": 22,
-            "source_mcc": "466",
-            "confused_gNBId": 16,
-            "confused_cellLocalId": 264,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 11,
-            "confused_mcc": "466",
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "confusion_pci": 150,
-            "confused_mnc": "55",
-            "source_gNBId": 5,
-            "source_gNBId_length": 22,
-            "confused_gNBId_length": 22,
-            "source_mcc": "466",
-            "confused_gNBId": 6,
-            "confused_cellLocalId": 264,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 2,
-            "confused_mcc": "466",
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "confusion_pci": 150,
-            "confused_mnc": "55",
-            "source_gNBId": 2,
-            "source_gNBId_length": 22,
-            "confused_gNBId_length": 22,
-            "source_mcc": "466",
-            "confused_gNBId": 6,
-            "confused_cellLocalId": 264,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 5,
-            "confused_mcc": "466",
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "confusion_pci": 150,
-            "confused_mnc": "55",
-            "source_gNBId": 16,
-            "source_gNBId_length": 22,
-            "confused_gNBId_length": 22,
-            "source_mcc": "466",
-            "confused_gNBId": 11,
-            "confused_cellLocalId": 264,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 10,
-            "confused_mcc": "466",
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "confusion_pci": 150,
-            "confused_mnc": "55",
-            "source_gNBId": 10,
-            "source_gNBId_length": 22,
-            "confused_gNBId_length": 22,
-            "source_mcc": "466",
-            "confused_gNBId": 11,
-            "confused_cellLocalId": 264,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 16,
-            "confused_mcc": "466",
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "confusion_pci": 150,
-            "confused_mnc": "55",
-            "source_gNBId": 6,
-            "source_gNBId_length": 22,
-            "confused_gNBId_length": 22,
-            "source_mcc": "466",
-            "confused_gNBId": 5,
-            "confused_cellLocalId": 264,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 8,
-            "confused_mcc": "466",
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "confusion_pci": 150,
-            "confused_mnc": "55",
-            "source_gNBId": 8,
-            "source_gNBId_length": 22,
-            "confused_gNBId_length": 22,
-            "source_mcc": "466",
-            "confused_gNBId": 5,
-            "confused_cellLocalId": 264,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 6,
-            "confused_mcc": "466",
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "confusion_pci": 150,
-            "confused_mnc": "55",
-            "source_gNBId": 16,
-            "source_gNBId_length": 22,
-            "confused_gNBId_length": 22,
-            "source_mcc": "466",
-            "confused_gNBId": 12,
-            "confused_cellLocalId": 264,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 10,
-            "confused_mcc": "466",
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "confusion_pci": 150,
-            "confused_mnc": "55",
-            "source_gNBId": 10,
-            "source_gNBId_length": 22,
-            "confused_gNBId_length": 22,
-            "source_mcc": "466",
-            "confused_gNBId": 12,
-            "confused_cellLocalId": 264,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 16,
-            "confused_mcc": "466",
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "confusion_pci": 150,
-            "confused_mnc": "55",
-            "source_gNBId": 6,
-            "source_gNBId_length": 22,
-            "confused_gNBId_length": 22,
-            "source_mcc": "466",
-            "confused_gNBId": 17,
-            "confused_cellLocalId": 264,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 1,
-            "confused_mcc": "466",
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "confusion_pci": 150,
-            "confused_mnc": "55",
-            "source_gNBId": 6,
-            "source_gNBId_length": 22,
-            "confused_gNBId_length": 22,
-            "source_mcc": "466",
-            "confused_gNBId": 17,
-            "confused_cellLocalId": 264,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 2,
-            "confused_mcc": "466",
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "confusion_pci": 150,
-            "confused_mnc": "55",
-            "source_gNBId": 1,
-            "source_gNBId_length": 22,
-            "confused_gNBId_length": 22,
-            "source_mcc": "466",
-            "confused_gNBId": 17,
-            "confused_cellLocalId": 264,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 6,
-            "confused_mcc": "466",
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "confusion_pci": 150,
-            "confused_mnc": "55",
-            "source_gNBId": 1,
-            "source_gNBId_length": 22,
-            "confused_gNBId_length": 22,
-            "source_mcc": "466",
-            "confused_gNBId": 17,
-            "confused_cellLocalId": 264,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 2,
-            "confused_mcc": "466",
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "confusion_pci": 150,
-            "confused_mnc": "55",
-            "source_gNBId": 2,
-            "source_gNBId_length": 22,
-            "confused_gNBId_length": 22,
-            "source_mcc": "466",
-            "confused_gNBId": 17,
-            "confused_cellLocalId": 264,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 6,
-            "confused_mcc": "466",
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "confusion_pci": 150,
-            "confused_mnc": "55",
-            "source_gNBId": 2,
-            "source_gNBId_length": 22,
-            "confused_gNBId_length": 22,
-            "source_mcc": "466",
-            "confused_gNBId": 17,
-            "confused_cellLocalId": 264,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 1,
-            "confused_mcc": "466",
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "confusion_pci": 150,
-            "confused_mnc": "55",
-            "source_gNBId": 6,
-            "source_gNBId_length": 22,
-            "confused_gNBId_length": 22,
-            "source_mcc": "466",
-            "confused_gNBId": 2,
-            "confused_cellLocalId": 264,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 1,
-            "confused_mcc": "466",
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "confusion_pci": 150,
-            "confused_mnc": "55",
-            "source_gNBId": 1,
-            "source_gNBId_length": 22,
-            "confused_gNBId_length": 22,
-            "source_mcc": "466",
-            "confused_gNBId": 2,
-            "confused_cellLocalId": 264,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 6,
-            "confused_mcc": "466",
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "confusion_pci": 150,
-            "confused_mnc": "55",
-            "source_gNBId": 16,
-            "source_gNBId_length": 22,
-            "confused_gNBId_length": 22,
-            "source_mcc": "466",
-            "confused_gNBId": 10,
-            "confused_cellLocalId": 264,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 12,
-            "confused_mcc": "466",
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "confusion_pci": 150,
-            "confused_mnc": "55",
-            "source_gNBId": 12,
-            "source_gNBId_length": 22,
-            "confused_gNBId_length": 22,
-            "source_mcc": "466",
-            "confused_gNBId": 10,
-            "confused_cellLocalId": 264,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 16,
-            "confused_mcc": "466",
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "confusion_pci": 150,
-            "confused_mnc": "55",
-            "source_gNBId": 16,
-            "source_gNBId_length": 22,
-            "confused_gNBId_length": 22,
-            "source_mcc": "466",
-            "confused_gNBId": 13,
-            "confused_cellLocalId": 264,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 12,
-            "confused_mcc": "466",
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "confusion_pci": 150,
-            "confused_mnc": "55",
-            "source_gNBId": 12,
-            "source_gNBId_length": 22,
-            "confused_gNBId_length": 22,
-            "source_mcc": "466",
-            "confused_gNBId": 13,
-            "confused_cellLocalId": 264,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 16,
-            "confused_mcc": "466",
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          }
-        ],
-        "collision_cell_new": [
-          {
-            "collision_pci": 150,
-            "source_gNBId": 16,
-            "source_mcc": "466",
-            "source_gNBId_length": 22,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 12,
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "collision_pci": 150,
-            "source_gNBId": 16,
-            "source_mcc": "466",
-            "source_gNBId_length": 22,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 10,
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "collision_pci": 150,
-            "source_gNBId": 6,
-            "source_mcc": "466",
-            "source_gNBId_length": 22,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 5,
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "collision_pci": 150,
-            "source_gNBId": 6,
-            "source_mcc": "466",
-            "source_gNBId_length": 22,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 2,
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "collision_pci": 151,
-            "source_gNBId": 11,
-            "source_mcc": "466",
-            "source_gNBId_length": 22,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 13,
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "collision_pci": 150,
-            "source_gNBId": 5,
-            "source_mcc": "466",
-            "source_gNBId_length": 22,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 6,
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "collision_pci": 150,
-            "source_gNBId": 5,
-            "source_mcc": "466",
-            "source_gNBId_length": 22,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 8,
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "collision_pci": 150,
-            "source_gNBId": 12,
-            "source_mcc": "466",
-            "source_gNBId_length": 22,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 16,
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "collision_pci": 150,
-            "source_gNBId": 12,
-            "source_mcc": "466",
-            "source_gNBId_length": 22,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 10,
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "collision_pci": 150,
-            "source_gNBId": 1,
-            "source_mcc": "466",
-            "source_gNBId_length": 22,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 2,
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "collision_pci": 150,
-            "source_gNBId": 2,
-            "source_mcc": "466",
-            "source_gNBId_length": 22,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 6,
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "collision_pci": 150,
-            "source_gNBId": 2,
-            "source_mcc": "466",
-            "source_gNBId_length": 22,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 1,
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "collision_pci": 150,
-            "source_gNBId": 10,
-            "source_mcc": "466",
-            "source_gNBId_length": 22,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 16,
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "collision_pci": 150,
-            "source_gNBId": 10,
-            "source_mcc": "466",
-            "source_gNBId_length": 22,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 12,
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "collision_pci": 151,
-            "source_gNBId": 13,
-            "source_mcc": "466",
-            "source_gNBId_length": 22,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 11,
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          },
-          {
-            "collision_pci": 150,
-            "source_gNBId": 8,
-            "source_mcc": "466",
-            "source_gNBId_length": 22,
-            "source_cellLocalId": 264,
-            "target_cellLocalId": 264,
-            "source_mnc": "55",
-            "target_gNBId": 5,
-            "target_gNBId_length": 22,
-            "target_mcc": "466",
-            "target_mnc": "55"
-          }
-        ],
-        "cellIndividualResult": [
-          {
-            "nrPCI": 150,
-            "NRCellRelation": [
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 151,
-                "gNBId": 11,
-                "PLMNId_MCC": "466",
-                "nRPCI": 151,
-                "PLMNId_MNC": "55"
-              },
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 150,
-                "gNBId": 12,
-                "PLMNId_MCC": "466",
-                "nRPCI": 150,
-                "PLMNId_MNC": "55"
-              },
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 150,
-                "gNBId": 10,
-                "PLMNId_MCC": "466",
-                "nRPCI": 150,
-                "PLMNId_MNC": "55"
-              },
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 151,
-                "gNBId": 13,
-                "PLMNId_MCC": "466",
-                "nRPCI": 151,
-                "PLMNId_MNC": "55"
-              }
-            ],
-            "gNBId": 16,
-            "cellLocalId": "00000100001000",
-            "PLMNId_MCC": "466",
-            "PLMNId_MNC": "55"
-          },
-          {
-            "nrPCI": 150,
-            "NRCellRelation": [
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 150,
-                "gNBId": 5,
-                "PLMNId_MCC": "466",
-                "nRPCI": 150,
-                "PLMNId_MNC": "55"
-              },
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 151,
-                "gNBId": 17,
-                "PLMNId_MCC": "466",
-                "nRPCI": 151,
-                "PLMNId_MNC": "55"
-              },
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 150,
-                "gNBId": 2,
-                "PLMNId_MCC": "466",
-                "nRPCI": 150,
-                "PLMNId_MNC": "55"
-              }
-            ],
-            "gNBId": 6,
-            "cellLocalId": "00000100001000",
-            "PLMNId_MCC": "466",
-            "PLMNId_MNC": "55"
-          },
-          {
-            "nrPCI": 151,
-            "NRCellRelation": [
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 150,
-                "gNBId": 16,
-                "PLMNId_MCC": "466",
-                "nRPCI": 150,
-                "PLMNId_MNC": "55"
-              },
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 150,
-                "gNBId": 10,
-                "PLMNId_MCC": "466",
-                "nRPCI": 150,
-                "PLMNId_MNC": "55"
-              },
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 151,
-                "gNBId": 13,
-                "PLMNId_MCC": "466",
-                "nRPCI": 151,
-                "PLMNId_MNC": "55"
-              }
-            ],
-            "gNBId": 11,
-            "cellLocalId": "00000100001000",
-            "PLMNId_MCC": "466",
-            "PLMNId_MNC": "55"
-          },
-          {
-            "nrPCI": 151,
-            "NRCellRelation": [
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 150,
-                "gNBId": 14,
-                "PLMNId_MCC": "466",
-                "nRPCI": 150,
-                "PLMNId_MNC": "55"
-              }
-            ],
-            "gNBId": 15,
-            "cellLocalId": "00000100001000",
-            "PLMNId_MCC": "466",
-            "PLMNId_MNC": "55"
-          },
-          {
-            "nrPCI": 150,
-            "NRCellRelation": [
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 150,
-                "gNBId": 6,
-                "PLMNId_MCC": "466",
-                "nRPCI": 150,
-                "PLMNId_MNC": "55"
-              },
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 150,
-                "gNBId": 8,
-                "PLMNId_MCC": "466",
-                "nRPCI": 150,
-                "PLMNId_MNC": "55"
-              }
-            ],
-            "gNBId": 5,
-            "cellLocalId": "00000100001000",
-            "PLMNId_MCC": "466",
-            "PLMNId_MNC": "55"
-          },
-          {
-            "nrPCI": 150,
-            "NRCellRelation": [
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 151,
-                "gNBId": 15,
-                "PLMNId_MCC": "466",
-                "nRPCI": 151,
-                "PLMNId_MNC": "55"
-              }
-            ],
-            "gNBId": 14,
-            "cellLocalId": "00000100001000",
-            "PLMNId_MCC": "466",
-            "PLMNId_MNC": "55"
-          },
-          {
-            "nrPCI": 150,
-            "NRCellRelation": [
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 150,
-                "gNBId": 16,
-                "PLMNId_MCC": "466",
-                "nRPCI": 150,
-                "PLMNId_MNC": "55"
-              },
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 150,
-                "gNBId": 10,
-                "PLMNId_MCC": "466",
-                "nRPCI": 150,
-                "PLMNId_MNC": "55"
-              },
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 151,
-                "gNBId": 13,
-                "PLMNId_MCC": "466",
-                "nRPCI": 151,
-                "PLMNId_MNC": "55"
-              }
-            ],
-            "gNBId": 12,
-            "cellLocalId": "00000100001000",
-            "PLMNId_MCC": "466",
-            "PLMNId_MNC": "55"
-          },
-          {
-            "nrPCI": 150,
-            "NRCellRelation": [
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 151,
-                "gNBId": 17,
-                "PLMNId_MCC": "466",
-                "nRPCI": 151,
-                "PLMNId_MNC": "55"
-              },
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 150,
-                "gNBId": 2,
-                "PLMNId_MCC": "466",
-                "nRPCI": 150,
-                "PLMNId_MNC": "55"
-              }
-            ],
-            "gNBId": 1,
-            "cellLocalId": "00000100001000",
-            "PLMNId_MCC": "466",
-            "PLMNId_MNC": "55"
-          },
-          {
-            "nrPCI": 151,
-            "NRCellRelation": [
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 150,
-                "gNBId": 6,
-                "PLMNId_MCC": "466",
-                "nRPCI": 150,
-                "PLMNId_MNC": "55"
-              },
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 150,
-                "gNBId": 1,
-                "PLMNId_MCC": "466",
-                "nRPCI": 150,
-                "PLMNId_MNC": "55"
-              },
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 150,
-                "gNBId": 2,
-                "PLMNId_MCC": "466",
-                "nRPCI": 150,
-                "PLMNId_MNC": "55"
-              }
-            ],
-            "gNBId": 17,
-            "cellLocalId": "00000100001000",
-            "PLMNId_MCC": "466",
-            "PLMNId_MNC": "55"
-          },
-          {
-            "nrPCI": 150,
-            "NRCellRelation": [
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 150,
-                "gNBId": 6,
-                "PLMNId_MCC": "466",
-                "nRPCI": 150,
-                "PLMNId_MNC": "55"
-              },
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 150,
-                "gNBId": 1,
-                "PLMNId_MCC": "466",
-                "nRPCI": 150,
-                "PLMNId_MNC": "55"
-              },
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 151,
-                "gNBId": 17,
-                "PLMNId_MCC": "466",
-                "nRPCI": 151,
-                "PLMNId_MNC": "55"
-              }
-            ],
-            "gNBId": 2,
-            "cellLocalId": "00000100001000",
-            "PLMNId_MCC": "466",
-            "PLMNId_MNC": "55"
-          },
-          {
-            "nrPCI": 150,
-            "NRCellRelation": [
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 150,
-                "gNBId": 16,
-                "PLMNId_MCC": "466",
-                "nRPCI": 150,
-                "PLMNId_MNC": "55"
-              },
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 151,
-                "gNBId": 11,
-                "PLMNId_MCC": "466",
-                "nRPCI": 151,
-                "PLMNId_MNC": "55"
-              },
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 150,
-                "gNBId": 12,
-                "PLMNId_MCC": "466",
-                "nRPCI": 150,
-                "PLMNId_MNC": "55"
-              }
-            ],
-            "gNBId": 10,
-            "cellLocalId": "00000100001000",
-            "PLMNId_MCC": "466",
-            "PLMNId_MNC": "55"
-          },
-          {
-            "nrPCI": 151,
-            "NRCellRelation": [
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 150,
-                "gNBId": 16,
-                "PLMNId_MCC": "466",
-                "nRPCI": 150,
-                "PLMNId_MNC": "55"
-              },
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 151,
-                "gNBId": 11,
-                "PLMNId_MCC": "466",
-                "nRPCI": 151,
-                "PLMNId_MNC": "55"
-              },
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 150,
-                "gNBId": 12,
-                "PLMNId_MCC": "466",
-                "nRPCI": 150,
-                "PLMNId_MNC": "55"
-              }
-            ],
-            "gNBId": 13,
-            "cellLocalId": "00000100001000",
-            "PLMNId_MCC": "466",
-            "PLMNId_MNC": "55"
-          },
-          {
-            "nrPCI": 150,
-            "NRCellRelation": [
-              {
-                "cellLocalId": "00000100001000",
-                "nRTCI": 150,
-                "gNBId": 5,
-                "PLMNId_MCC": "466",
-                "nRPCI": 150,
-                "PLMNId_MNC": "55"
-              }
-            ],
-            "gNBId": 8,
-            "cellLocalId": "00000100001000",
-            "PLMNId_MCC": "466",
-            "PLMNId_MNC": "55"
-          }
-        ]
+        "collision_cell_new": [],
+        "collision_count_new": []
       }
     };
-    
 }


### PR DESCRIPTION
1. 調整 queryBsInfo 與 multiCalculateBs_response 用 local-files 便於外包調整特定情況。
2. queryBsInfo 的 local-files 新增分佈式沒 info 數據的狀況。
3. 調整 For_queryBsInfo_dist_BS 分佈式用 interface 將 info 定義改為Info_dist[] | {} 以應付info :{} 的狀況。
4. 場域優化重置清除計算結果函數resetFieldOptimizationForm()，加入會將頁籤重置顯示回 CCO。
5. 調整基站資訊頁計算分佈式 Cell 數方式，改跟基站主頁方法相同，遍歷 components 拓樸分佈來得知 Cell 數。