### PR TITLE
BS Mgmt 資訊頁 - 完成"基本參數"區各對應參數填入進對應欄位

### DIFF
--- a/src/app/bs-management/bs-info/bs-info.component.html
+++ b/src/app/bs-management/bs-info/bs-info.component.html
@@ -8,7 +8,8 @@
 
   <div class="main collabsible">
 
-    <div class="baseInfo"><!-- 基本訊息區 -->
+    <!-- 基本訊息區 -->
+    <div class="baseInfo">
       <span>
         {{ languageService.i18n['basic.info'] }}
         <button (click)="openBsBasicInfoEditWindow()" >{{ languageService.i18n['BS.editSettings'] }}</button>
@@ -248,7 +249,8 @@
     </ng-template>
 
 
-    <div class="topology"><!-- 網元拓樸圖區 -->
+    <!-- 網元拓樸圖區 -->
+    <div class="topology">
       <span>{{ languageService.i18n['BS.topology'] }}</span>
       <input id="topology" class="toggle" type="checkbox">
       <label for="topology" class="lbl-toggle"></label>
@@ -324,177 +326,210 @@
       </div>
     </div>
 
-    <div class="parameters"><!-- 基站參數 -->
-      <span>
-        {{ languageService.i18n['BS.parameters'] }}
-        
-        <div class="logTab">
-          <mat-button-toggle-group name="bsParametersType" [(ngModel)]="bsParametersType" (change)="changeBsParametersType( $event )">
-            <mat-button-toggle value="Basic">Basic</mat-button-toggle>
-            <mat-button-toggle value="Advanced">Advanced</mat-button-toggle>
-          </mat-button-toggle-group>
-        </div>
-      </span>
-      <input id="bsParameters" class="toggle" type="checkbox">
-      <label for="bsParameters" class="lbl-toggle"></label>
-      
-      <div class="collapsible-content">
-        <div class="content-inner">
-          
-          <form>
-            <div class="filter">
-              <span><label>Cell:</label>
-                <select>
-                  <option>
-                    Cell#1 (NCI=0x000024001)
-                  </option>
-                  <option>
-                    Cell#2 (NCI=0x000024002)
-                  </option>
-                  <option>
-                    Cell#3 (NCI=0x000024003)
-                  </option>
-                  <option>
-                    Cell#4 (NCI=0x000024004)
-                  </option>
-                </select>
-              </span>
-          
-              <span tooltip="{{ languageService.i18n['search'] }}" class="material-icons" >search</span>
-          
-              <!-- Button of clear_search_ScheduleList -->
-              <span tooltip="{{ languageService.i18n['clear_search'] }}" class="material-symbols-outlined">clear</span>
 
-            </div>
-          </form>
-
-          <!-- Basic -->
-          <div class="collabsible" *ngIf=" bsParametersType === 'Basic' ">
-            <span class="forALL_btn">
-              For All: 
-              <button>DB → gNB</button>
-              <button>DB ← gNB</button>
-            </span>
-            <div class="table basicParmType">
-              <table>
-                <thead>
-                  <tr>
-                    <th>Items</th>
-                    <th>Athena Ochestreator DB</th>
-                    <th>Network Element Datastore</th>
-                    <th>Conflict</th>
-                    <th>Action</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>PLMNID_MCC</td>
-                    <td>466</td> <!-- extension_info.NRCellDU.db.pLMNId_MCC -->
-                    <td>466</td> <!-- extension_info.NRCellDU.ds.pLMNId_MCC -->
-                    <td>No</td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>PLMNID_MNC</td>
-                    <td>66</td> <!-- extension_info.NRCellDU.db.pLMNId_MNC -->
-                    <td>66</td> <!-- extension_info.NRCellDU.ds.pLMNId_MNC -->
-                    <td>No</td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>gNB ID</td>
-                    <td>9</td> <!-- extension_info.NRCellDU.db.gNBId -->
-                    <td>9</td> <!-- extension_info.NRCellDU.ds.gNBId -->
-                    <td>No</td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>gNB ID Length</td>
-                    <td>22</td> <!-- extension_info.NRCellDU.db.gNBIdLength -->
-                    <td>22</td> <!-- extension_info.NRCellDU.ds.gNBIdLength -->
-                    <td>No</td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>Cell Local ID ( binary value )</td>
-                    <td>10</td> <!-- extension_info.NRCellDU.db.cellLocalId -->
-                    <td>10</td> <!-- extension_info.NRCellDU.ds.cellLocalId -->
-                    <td>No</td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>NCI ( hexadecimal value )</td>
-                    <td>000024001</td> <!-- extension_info.NRCellDU.db.cellLocalId -->
-                    <td>000024001</td> <!-- extension_info.nci -->
-                    <td>No</td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>PCI</td>
-                    <td>158 <!-- extension_info.NRCellDU.db.nRPCI -->
-                      <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
-                    </td>
-                    <td>100</td> <!-- extension_info.NRCellDU.ds.nRPCI -->
-                    <td>Yes</td>
-                    <td><span><button>DB → gNB</button><button>DB ← gNB</button></span></td>
-                  </tr>
-                  <tr>
-                    <td>NR-ARFCN-DL</td>
-                    <td>723333 <!-- extension_info.NRCellDU.db.arfcnDL -->
-                      <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
-                    </td>
-                    <td>723333</td><!-- extension_info.NRCellDU.ds.arfcnDL -->
-                    <td>No</td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>NR-ARFCN-UL</td>
-                    <td>723333 <!-- extension_info.NRCellDU.db.arfcnUL -->
-                      <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
-                    </td>
-                    <td>723333</td><!-- extension_info.NRCellDU.ds.arfcnUL -->
-                    <td>No</td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>Channel Bandwidth</td>
-                    <td>20 <!-- extension_info.NRCellDU.db.bSChannelBwDL -->
-                      <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
-                    </td>
-                    <td>20</td><!-- extension_info.NRCellDU.ds.bSChannelBwDL -->
-                    <td>No</td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>Tx Power</td>
-                    <td>8<!-- NRSectorCarrier.db.configuredMaxTxPower -->
-                      <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
-                    </td>
-                    <td>10</td><!-- NRSectorCarrier.ds.configuredMaxTxPower -->
-                    <td>Yes</td>
-                    <td><span><button>DB → gNB</button><button>DB ← gNB</button></span></td>
-                  </tr>
-                  <tr>
-                    <td>TAC</td>
-                    <td>3000  <!-- extension_info.NRCellDU.db.nRTAC -->
-                      <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
-                    </td>
-                    <td>3001</td><!-- extension_info.NRCellDU.ds.nRTAC -->
-                    <td>Yes</td>
-                    <td><span><button>DB → gNB</button><button>DB ← gNB</button></span></td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
+    <!-- 基站參數 -->
+    <div class="parameters">
+        <span>
+          {{ languageService.i18n['BS.parameters'] }}
+          
+          <div class="logTab">
+            <mat-button-toggle-group name="bsParametersType" [(ngModel)]="bsParametersType" (change)="changeBsParametersType($event)">
+              <mat-button-toggle value="Basic">Basic</mat-button-toggle>
+              <mat-button-toggle value="Advanced">Advanced</mat-button-toggle>
+            </mat-button-toggle-group>
           </div>
+        </span>
+        <input id="bsParameters" class="toggle" type="checkbox">
+        <label for="bsParameters" class="lbl-toggle"></label>
+        
+        <div class="collapsible-content">
+          <div class="content-inner">
+            
+            <form>
+              <div class="filter">
+                <span><label>Cell:</label>
+                  <select [(ngModel)]="selectedNci" name="selectedNci">
+                    <option *ngFor="let nci of nciList" [value]="nci">
+                      Cell#{{ nciList.indexOf(nci) + 1 }} (NCI=0x{{ nci }})
+                    </option>
+                  </select>
+                </span>
+            
+                <span tooltip="{{ languageService.i18n['search'] }}" class="material-icons" (click)="onSearchClick()">search</span>
+            
+                <!-- Button of clear_search_ScheduleList -->
+                <span tooltip="{{ languageService.i18n['clear_search'] }}" class="material-symbols-outlined" (click)="onClearClick()">clear</span>
+            
+              </div>
+            </form>
+      
+            <!-- Basic @2024/04/15 ok -->
+            <div class="collabsible" *ngIf="bsParametersType === 'Basic'">
+              <span class="forALL_btn">
+                For All: 
+                <button>DB → gNB</button>
+                <button>DB ← gNB</button>
+              </span>
+              <div class="table basicParmType">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Items</th>
+                      <th>Athena Ochestreator DB</th>
+                      <th>Network Element Datastore</th>
+                      <th>Conflict</th>
+                      <th>Action</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>PLMNID_MCC</td>
+                      <td>{{ selectedExtensionInfo?.gNBCUFunction?.db?.pLMNId_MCC }}</td>
+                      <td>{{ selectedExtensionInfo?.gNBCUFunction?.ds?.pLMNId_MCC }}</td>
+                      <td>{{ (selectedExtensionInfo?.gNBCUFunction?.db?.pLMNId_MCC === selectedExtensionInfo?.gNBCUFunction?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                      <td>
+                        <span *ngIf="selectedExtensionInfo?.gNBCUFunction?.db?.pLMNId_MCC !== selectedExtensionInfo?.gNBCUFunction?.ds?.pLMNId_MCC">
+                          <button>DB → gNB</button>
+                          <button>DB ← gNB</button>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>PLMNID_MNC</td>
+                      <td>{{ selectedExtensionInfo?.gNBCUFunction?.db?.pLMNId_MNC }}</td>
+                      <td>{{ selectedExtensionInfo?.gNBCUFunction?.ds?.pLMNId_MNC }}</td>
+                      <td>{{ (selectedExtensionInfo?.gNBCUFunction?.db?.pLMNId_MNC === selectedExtensionInfo?.gNBCUFunction?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                      <td>
+                        <span *ngIf="selectedExtensionInfo?.gNBCUFunction?.db?.pLMNId_MNC !== selectedExtensionInfo?.gNBCUFunction?.ds?.pLMNId_MNC">
+                          <button>DB → gNB</button>
+                          <button>DB ← gNB</button>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>gNB ID</td>
+                      <td>{{ selectedExtensionInfo?.gNBId }}</td>
+                      <td>{{ selectedExtensionInfo?.gNBId }}</td>
+                      <td>No</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td>gNB ID Length</td>
+                      <td>{{ selectedExtensionInfo?.gNBIdLength }}</td>
+                      <td>{{ selectedExtensionInfo?.gNBIdLength }}</td>
+                      <td>No</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td>Cell Local ID (binary value)</td>
+                      <td>{{ selectedExtensionInfo?.cellLocalId }}</td>
+                      <td>{{ selectedExtensionInfo?.cellLocalId }}</td>
+                      <td>No</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td>NCI (hexadecimal value)</td>
+                      <td>{{ selectedExtensionInfo?.nci }}</td>
+                      <td>{{ selectedExtensionInfo?.nci }}</td>
+                      <td>No</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td>PCI</td>
+                      <td>{{ selectedExtensionInfo?.NRCellDU?.db?.nRPCI }}
+                        <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                      </td>
+                      <td>{{ selectedExtensionInfo?.NRCellDU?.ds?.nRPCI }}</td>
+                      <td>{{ (selectedExtensionInfo?.NRCellDU?.db?.nRPCI === selectedExtensionInfo?.NRCellDU?.ds?.nRPCI) ? 'No' : 'Yes' }}</td>
+                      <td>
+                        <span *ngIf="selectedExtensionInfo?.NRCellDU?.db?.nRPCI !== selectedExtensionInfo?.NRCellDU?.ds?.nRPCI">
+                          <button>DB → gNB</button>
+                          <button>DB ← gNB</button>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>NR-ARFCN-DL</td>
+                      <td>{{ selectedExtensionInfo?.NRCellDU?.db?.arfcnDL }}
+                        <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                      </td>
+                      <td>{{ selectedExtensionInfo?.NRCellDU?.ds?.arfcnDL }}</td>
+                      <td>{{ (selectedExtensionInfo?.NRCellDU?.db?.arfcnDL === selectedExtensionInfo?.NRCellDU?.ds?.arfcnDL) ? 'No' : 'Yes' }}</td>
+                      <td>
+                        <span *ngIf="selectedExtensionInfo?.NRCellDU?.db?.arfcnDL !== selectedExtensionInfo?.NRCellDU?.ds?.arfcnDL">
+                          <button>DB → gNB</button>
+                          <button>DB ← gNB</button>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>NR-ARFCN-UL</td>
+                      <td>{{ selectedExtensionInfo?.NRCellDU?.db?.arfcnUL }}
+                        <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                      </td>
+                      <td>{{ selectedExtensionInfo?.NRCellDU?.ds?.arfcnUL }}</td>
+                      <td>{{ (selectedExtensionInfo?.NRCellDU?.db?.arfcnUL === selectedExtensionInfo?.NRCellDU?.ds?.arfcnUL) ? 'No' : 'Yes' }}</td>
+                      <td>
+                        <span *ngIf="selectedExtensionInfo?.NRCellDU?.db?.arfcnUL !== selectedExtensionInfo?.NRCellDU?.ds?.arfcnUL">
+                          <button>DB → gNB</button>
+                          <button>DB ← gNB</button>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>Channel Bandwidth</td>
+                      <td>{{ selectedExtensionInfo?.NRCellDU?.db?.bSChannelBwDL }}
+                        <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                      </td>
+                      <td>{{ selectedExtensionInfo?.NRCellDU?.ds?.bSChannelBwDL }}</td>
+                      <td>{{ (selectedExtensionInfo?.NRCellDU?.db?.bSChannelBwDL === selectedExtensionInfo?.NRCellDU?.ds?.bSChannelBwDL) ? 'No' : 'Yes' }}</td>
+                      <td>
+                        <span *ngIf="selectedExtensionInfo?.NRCellDU?.db?.bSChannelBwDL !== selectedExtensionInfo?.NRCellDU?.ds?.bSChannelBwDL">
+                          <button>DB → gNB</button>
+                          <button>DB ← gNB</button>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>Tx Power</td>
+                      <td>{{ selectedExtensionInfo?.NRSectorCarrier?.db?.configuredMaxTxPower }}
+                        <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                      </td>
+                      <td>{{ selectedExtensionInfo?.NRSectorCarrier?.ds?.configuredMaxTxPower }}</td>
+                      <td>{{ (selectedExtensionInfo?.NRSectorCarrier?.db?.configuredMaxTxPower === selectedExtensionInfo?.NRSectorCarrier?.ds?.configuredMaxTxPower) ? 'No' : 'Yes' }}</td>
+                      <td>
+                        <span *ngIf="selectedExtensionInfo?.NRSectorCarrier?.db?.configuredMaxTxPower !== selectedExtensionInfo?.NRSectorCarrier?.ds?.configuredMaxTxPower">
+                          <button>DB → gNB</button>
+                          <button>DB ← gNB</button>
+                        </span>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>TAC</td>
+                      <td>{{ selectedExtensionInfo?.NRCellDU?.db?.nRTAC }}
+                        <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                      </td>
+                      <td>{{ selectedExtensionInfo?.NRCellDU?.ds?.nRTAC }}</td>
+                      <td>{{ (selectedExtensionInfo?.NRCellDU?.db?.nRTAC === selectedExtensionInfo?.NRCellDU?.ds?.nRTAC) ? 'No' : 'Yes' }}</td>
+                      <td>
+                        <span *ngIf="selectedExtensionInfo?.NRCellDU?.db?.nRTAC !== selectedExtensionInfo?.NRCellDU?.ds?.nRTAC">
+                          <button>DB → gNB</button>
+                          <button>DB ← gNB</button>
+                        </span>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
 
-          <!-- Advanced -->
+          <!-- Advanced @2024/04/15 ok -->
           <div class="collabsible Advanced" *ngIf=" bsParametersType === 'Advanced' ">
             <div class="">
               <div class="">
                 <div class="collabsible">
 
-                  <!-- gNBCUFunction -->
+                  <!-- gNBCUFunction @2024/04/15 ok -->
                   <div>
                     <span>gNBCUFunction</span>
                     <input id="gNBCUFunction" class="toggle" type="checkbox">
@@ -515,49 +550,79 @@
                             <tbody>
                               <tr>
                                 <td>gNBId</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.gNBCUFunction?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.gNBCUFunction?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.gNBCUFunction?.db?.gNBId === selectedExtensionInfo?.gNBCUFunction?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.gNBCUFunction?.db?.gNBId !== selectedExtensionInfo?.gNBCUFunction?.ds?.gNBId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>gNBIdLength</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.gNBCUFunction?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.gNBCUFunction?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.gNBCUFunction?.db?.gNBIdLength === selectedExtensionInfo?.gNBCUFunction?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.gNBCUFunction?.db?.gNBIdLength !== selectedExtensionInfo?.gNBCUFunction?.ds?.gNBIdLength">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MCC</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.gNBCUFunction?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.gNBCUFunction?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.gNBCUFunction?.db?.pLMNId_MCC === selectedExtensionInfo?.gNBCUFunction?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.gNBCUFunction?.db?.pLMNId_MCC !== selectedExtensionInfo?.gNBCUFunction?.ds?.pLMNId_MCC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MNC</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.gNBCUFunction?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.gNBCUFunction?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.gNBCUFunction?.db?.pLMNId_MNC === selectedExtensionInfo?.gNBCUFunction?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.gNBCUFunction?.db?.pLMNId_MNC !== selectedExtensionInfo?.gNBCUFunction?.ds?.pLMNId_MNC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>gNBCUName</td>
-                                <td>cu1
+                                <td>{{ selectedExtensionInfo?.gNBCUFunction?.db?.gNBCUName }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>CU123</td>
-                                <td>Yes</td>
-                                <td><button>DB → gNB</button><button>DB ← gNB</button></td>
+                                <td>{{ selectedExtensionInfo?.gNBCUFunction?.ds?.gNBCUName }}</td>
+                                <td>{{ (selectedExtensionInfo?.gNBCUFunction?.db?.gNBCUName === selectedExtensionInfo?.gNBCUFunction?.ds?.gNBCUName) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.gNBCUFunction?.db?.gNBCUName !== selectedExtensionInfo?.gNBCUFunction?.ds?.gNBCUName">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>gNB_type</td>
-                                <td>SA
+                                <td>{{ selectedExtensionInfo?.gNBCUFunction?.db?.['gNB-type'] }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>SA</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.gNBCUFunction?.ds?.['gNB-type']  }}</td>
+                                <td>{{ (selectedExtensionInfo?.gNBCUFunction?.db?.['gNB-type']  === selectedExtensionInfo?.gNBCUFunction?.ds?.['gNB-type'] ) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.gNBCUFunction?.db?.['gNB-type']  !== selectedExtensionInfo?.gNBCUFunction?.ds?.['gNB-type'] ">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                             </tbody>
                           </table>
@@ -566,7 +631,7 @@
                     </div>
                   </div>
 
-                  <!-- peeParametersList_CU -->
+                  <!-- peeParametersList_CU @2024/04/15 ok -->
                   <div>
                     <span>peeParametersList_CU</span>
                     <input id="peeParametersList_CU" class="toggle" type="checkbox">
@@ -586,95 +651,150 @@
                             </thead>
                             <tbody>
                               <tr>
-                                <td>gNBId:</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBId</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_CU?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_CU?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_CU?.db?.gNBId === selectedExtensionInfo?.peeParametersList_CU?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_CU?.db?.gNBId !== selectedExtensionInfo?.peeParametersList_CU?.ds?.gNBId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>gNBIdLength:</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBIdLength</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_CU?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_CU?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_CU?.db?.gNBIdLength === selectedExtensionInfo?.peeParametersList_CU?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_CU?.db?.gNBIdLength !== selectedExtensionInfo?.peeParametersList_CU?.ds?.gNBIdLength">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MCC:</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MCC</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_CU?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_CU?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_CU?.db?.pLMNId_MCC === selectedExtensionInfo?.peeParametersList_CU?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_CU?.db?.pLMNId_MCC !== selectedExtensionInfo?.peeParametersList_CU?.ds?.pLMNId_MCC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MNC:</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MNC</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_CU?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_CU?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_CU?.db?.pLMNId_MNC === selectedExtensionInfo?.peeParametersList_CU?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_CU?.db?.pLMNId_MNC !== selectedExtensionInfo?.peeParametersList_CU?.ds?.pLMNId_MNC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>siteIdentification:</td>
-                                <td>bbb
+                                <td>siteIdentification</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_CU?.db?.siteIdentification }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>bbb</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_CU?.ds?.siteIdentification }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_CU?.db?.siteIdentification === selectedExtensionInfo?.peeParametersList_CU?.ds?.siteIdentification) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_CU?.db?.siteIdentification !== selectedExtensionInfo?.peeParametersList_CU?.ds?.siteIdentification">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>siteLatitude:</td>
-                                <td>10.0001
+                                <td>siteLatitude</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_CU?.db?.siteLatitude }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>10.0001</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_CU?.ds?.siteLatitude }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_CU?.db?.siteLatitude === selectedExtensionInfo?.peeParametersList_CU?.ds?.siteLatitude) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_CU?.db?.siteLatitude !== selectedExtensionInfo?.peeParametersList_CU?.ds?.siteLatitude">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>siteLongitude:</td>
-                                <td>10.0001
+                                <td>siteLongitude</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_CU?.db?.siteLongitude }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>10.0001</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_CU?.ds?.siteLongitude }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_CU?.db?.siteLongitude === selectedExtensionInfo?.peeParametersList_CU?.ds?.siteLongitude) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_CU?.db?.siteLongitude !== selectedExtensionInfo?.peeParametersList_CU?.ds?.siteLongitude">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>siteDescription:</td>
-                                <td>aaa
+                                <td>siteDescription</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_CU?.db?.siteDescription }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>aaa</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_CU?.ds?.siteDescription }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_CU?.db?.siteDescription === selectedExtensionInfo?.peeParametersList_CU?.ds?.siteDescription) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_CU?.db?.siteDescription !== selectedExtensionInfo?.peeParametersList_CU?.ds?.siteDescription">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>equipmentType:</td>
-                                <td>RRU
+                                <td>equipmentType</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_CU?.db?.equipmentType }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>RRU</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_CU?.ds?.equipmentType }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_CU?.db?.equipmentType === selectedExtensionInfo?.peeParametersList_CU?.ds?.equipmentType) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_CU?.db?.equipmentType !== selectedExtensionInfo?.peeParametersList_CU?.ds?.equipmentType">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>environmentType:</td>
-                                <td>Indoor
+                                <td>environmentType</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_CU?.db?.environmentType }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>Indoor</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_CU?.ds?.environmentType }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_CU?.db?.environmentType === selectedExtensionInfo?.peeParametersList_CU?.ds?.environmentType) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_CU?.db?.environmentType !== selectedExtensionInfo?.peeParametersList_CU?.ds?.environmentType">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>powerInterface:</td>
-                                <td>AC
+                                <td>powerInterface</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_CU?.db?.powerInterface }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>AC</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_CU?.ds?.powerInterface }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_CU?.db?.powerInterface === selectedExtensionInfo?.peeParametersList_CU?.ds?.powerInterface) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_CU?.db?.powerInterface !== selectedExtensionInfo?.peeParametersList_CU?.ds?.powerInterface">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                             </tbody>
                           </table>
@@ -683,7 +803,7 @@
                     </div>
                   </div>
 
-                  <!-- vnfParametersList_CU -->
+                  <!-- vnfParametersList_CU @2024/04/15 ok -->
                   <div>
                     <span>vnfParametersList_CU</span>
                     <input id="vnfParametersList_CU" class="toggle" type="checkbox">
@@ -703,68 +823,108 @@
                             </thead>
                             <tbody>
                               <tr>
-                                <td>gNBId:</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBId</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_CU?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_CU?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_CU?.db?.gNBId === selectedExtensionInfo?.vnfParametersList_CU?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_CU?.db?.gNBId !== selectedExtensionInfo?.vnfParametersList_CU?.ds?.gNBId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>gNBIdLength:</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBIdLength</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_CU?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_CU?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_CU?.db?.gNBIdLength === selectedExtensionInfo?.vnfParametersList_CU?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_CU?.db?.gNBIdLength !== selectedExtensionInfo?.vnfParametersList_CU?.ds?.gNBIdLength">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MCC:</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MCC</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_CU?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_CU?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_CU?.db?.pLMNId_MCC === selectedExtensionInfo?.vnfParametersList_CU?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_CU?.db?.pLMNId_MCC !== selectedExtensionInfo?.vnfParametersList_CU?.ds?.pLMNId_MCC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MNC:</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MNC</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_CU?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_CU?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_CU?.db?.pLMNId_MNC === selectedExtensionInfo?.vnfParametersList_CU?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_CU?.db?.pLMNId_MNC !== selectedExtensionInfo?.vnfParametersList_CU?.ds?.pLMNId_MNC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>autoScalable:</td>
-                                <td>true
+                                <td>autoScalable</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_CU?.db?.autoScalable }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>true</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_CU?.ds?.autoScalable }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_CU?.db?.autoScalable === selectedExtensionInfo?.vnfParametersList_CU?.ds?.autoScalable) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_CU?.db?.autoScalable !== selectedExtensionInfo?.vnfParametersList_CU?.ds?.autoScalable">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>flavourId:</td>
-                                <td>1
+                                <td>flavourId</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_CU?.db?.flavourId }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>1</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_CU?.ds?.flavourId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_CU?.db?.flavourId === selectedExtensionInfo?.vnfParametersList_CU?.ds?.flavourId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_CU?.db?.flavourId !== selectedExtensionInfo?.vnfParametersList_CU?.ds?.flavourId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>vnfInstanceId:</td>
-                                <td>1
+                                <td>vnfInstanceId</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_CU?.db?.vnfInstanceId }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>1</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_CU?.ds?.vnfInstanceId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_CU?.db?.vnfInstanceId === selectedExtensionInfo?.vnfParametersList_CU?.ds?.vnfInstanceId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_CU?.db?.vnfInstanceId !== selectedExtensionInfo?.vnfParametersList_CU?.ds?.vnfInstanceId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>vnfId:</td>
-                                <td>1
+                                <td>vnfdId</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_CU?.db?.vnfdId }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>1</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_CU?.ds?.vnfdId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_CU?.db?.vnfdId === selectedExtensionInfo?.vnfParametersList_CU?.ds?.vnfdId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_CU?.db?.vnfdId !== selectedExtensionInfo?.vnfParametersList_CU?.ds?.vnfdId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                             </tbody>
                           </table>
@@ -773,7 +933,7 @@
                     </div>
                   </div>
 
-                  <!-- EP_F1C_CU -->
+                  <!-- EP_F1C_CU @2024/04/15 ok -->
                   <div>
                     <span>EP_F1C_CU</span>
                     <input id="EP_F1C_CU" class="toggle" type="checkbox">
@@ -793,59 +953,94 @@
                             </thead>
                             <tbody>
                               <tr>
-                                <td>gNBId:</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBId</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_CU?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_CU?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1C_CU?.db?.gNBId === selectedExtensionInfo?.EP_F1C_CU?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1C_CU?.db?.gNBId !== selectedExtensionInfo?.EP_F1C_CU?.ds?.gNBId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>gNBIdLength:</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBIdLength</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_CU?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_CU?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1C_CU?.db?.gNBIdLength === selectedExtensionInfo?.EP_F1C_CU?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1C_CU?.db?.gNBIdLength !== selectedExtensionInfo?.EP_F1C_CU?.ds?.gNBIdLength">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MCC:</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MCC</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_CU?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_CU?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1C_CU?.db?.pLMNId_MCC === selectedExtensionInfo?.EP_F1C_CU?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1C_CU?.db?.pLMNId_MCC !== selectedExtensionInfo?.EP_F1C_CU?.ds?.pLMNId_MCC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MNC:</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MNC</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_CU?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_CU?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1C_CU?.db?.pLMNId_MNC === selectedExtensionInfo?.EP_F1C_CU?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1C_CU?.db?.pLMNId_MNC !== selectedExtensionInfo?.EP_F1C_CU?.ds?.pLMNId_MNC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>localAddress_ip_addr:</td>
-                                <td>1.1.1.1
+                                <td>localAddress_ip_addr</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_CU?.db?.localAddress_ip_addr }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>1.1.1.1</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_CU?.ds?.localAddress_ip_addr }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1C_CU?.db?.localAddress_ip_addr === selectedExtensionInfo?.EP_F1C_CU?.ds?.localAddress_ip_addr) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1C_CU?.db?.localAddress_ip_addr !== selectedExtensionInfo?.EP_F1C_CU?.ds?.localAddress_ip_addr">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>localAddress_vlan_id:</td>
-                                <td>1
+                                <td>localAddress_vlan_id</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_CU?.db?.localAddress_vlan_id }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>1</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_CU?.ds?.localAddress_vlan_id }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1C_CU?.db?.localAddress_vlan_id === selectedExtensionInfo?.EP_F1C_CU?.ds?.localAddress_vlan_id) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1C_CU?.db?.localAddress_vlan_id !== selectedExtensionInfo?.EP_F1C_CU?.ds?.localAddress_vlan_id">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>remoteAddress:</td>
-                                <td>1.1.2.1
+                                <td>remoteAddress</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_CU?.db?.remoteAddress }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>1.1.2.1</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_CU?.ds?.remoteAddress }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1C_CU?.db?.remoteAddress === selectedExtensionInfo?.EP_F1C_CU?.ds?.remoteAddress) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1C_CU?.db?.remoteAddress !== selectedExtensionInfo?.EP_F1C_CU?.ds?.remoteAddress">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                             </tbody>
                           </table>
@@ -854,7 +1049,7 @@
                     </div>
                   </div>
 
-                  <!-- EP_F1U_CU -->
+                  <!-- EP_F1U_CU @2024/04/15 ok -->
                   <div>
                     <span>EP_F1U_CU</span>
                     <input id="EP_F1U_CU" class="toggle" type="checkbox">
@@ -874,59 +1069,94 @@
                             </thead>
                             <tbody>
                               <tr>
-                                <td>gNBId:</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBId</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_CU?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_CU?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1U_CU?.db?.gNBId === selectedExtensionInfo?.EP_F1U_CU?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1U_CU?.db?.gNBId !== selectedExtensionInfo?.EP_F1U_CU?.ds?.gNBId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>gNBIdLength:</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBIdLength</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_CU?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_CU?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1U_CU?.db?.gNBIdLength === selectedExtensionInfo?.EP_F1U_CU?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1U_CU?.db?.gNBIdLength !== selectedExtensionInfo?.EP_F1U_CU?.ds?.gNBIdLength">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MCC:</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MCC</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_CU?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_CU?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1U_CU?.db?.pLMNId_MCC === selectedExtensionInfo?.EP_F1U_CU?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1U_CU?.db?.pLMNId_MCC !== selectedExtensionInfo?.EP_F1U_CU?.ds?.pLMNId_MCC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MNC:</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MNC</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_CU?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_CU?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1U_CU?.db?.pLMNId_MNC === selectedExtensionInfo?.EP_F1U_CU?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1U_CU?.db?.pLMNId_MNC !== selectedExtensionInfo?.EP_F1U_CU?.ds?.pLMNId_MNC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>localAddress_ip_addr:</td>
-                                <td>1.1.1.3
+                                <td>localAddress_ip_addr</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_CU?.db?.localAddress_ip_addr }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>1.1.1.3</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_CU?.ds?.localAddress_ip_addr }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1U_CU?.db?.localAddress_ip_addr === selectedExtensionInfo?.EP_F1U_CU?.ds?.localAddress_ip_addr) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1U_CU?.db?.localAddress_ip_addr !== selectedExtensionInfo?.EP_F1U_CU?.ds?.localAddress_ip_addr">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>localAddress_vlan_id:</td>
-                                <td>1
+                                <td>localAddress_vlan_id</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_CU?.db?.localAddress_vlan_id }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>1</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_CU?.ds?.localAddress_vlan_id }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1U_CU?.db?.localAddress_vlan_id === selectedExtensionInfo?.EP_F1U_CU?.ds?.localAddress_vlan_id) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1U_CU?.db?.localAddress_vlan_id !== selectedExtensionInfo?.EP_F1U_CU?.ds?.localAddress_vlan_id">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>remoteAddress:</td>
-                                <td>1.1.2.3
+                                <td>remoteAddress</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_CU?.db?.remoteAddress }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>1.1.2.3</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_CU?.ds?.remoteAddress }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1U_CU?.db?.remoteAddress === selectedExtensionInfo?.EP_F1U_CU?.ds?.remoteAddress) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1U_CU?.db?.remoteAddress !== selectedExtensionInfo?.EP_F1U_CU?.ds?.remoteAddress">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                             </tbody>
                           </table>
@@ -935,7 +1165,7 @@
                     </div>
                   </div>
 
-                  <!-- EP_NgC -->
+                  <!-- EP_NgC @2024/04/15 ok -->
                   <div>
                     <span>EP_NgC</span>
                     <input id="EP_NgC" class="toggle" type="checkbox">
@@ -955,59 +1185,94 @@
                             </thead>
                             <tbody>
                               <tr>
-                                <td>gNBId:</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBId</td>
+                                <td>{{ selectedExtensionInfo?.EP_NgC?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_NgC?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_NgC?.db?.gNBId === selectedExtensionInfo?.EP_NgC?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_NgC?.db?.gNBId !== selectedExtensionInfo?.EP_NgC?.ds?.gNBId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>gNBIdLength:</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBIdLength</td>
+                                <td>{{ selectedExtensionInfo?.EP_NgC?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_NgC?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_NgC?.db?.gNBIdLength === selectedExtensionInfo?.EP_NgC?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_NgC?.db?.gNBIdLength !== selectedExtensionInfo?.EP_NgC?.ds?.gNBIdLength">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MCC:</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MCC</td>
+                                <td>{{ selectedExtensionInfo?.EP_NgC?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_NgC?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_NgC?.db?.pLMNId_MCC === selectedExtensionInfo?.EP_NgC?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_NgC?.db?.pLMNId_MCC !== selectedExtensionInfo?.EP_NgC?.ds?.pLMNId_MCC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MNC:</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MNC</td>
+                                <td>{{ selectedExtensionInfo?.EP_NgC?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_NgC?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_NgC?.db?.pLMNId_MNC === selectedExtensionInfo?.EP_NgC?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_NgC?.db?.pLMNId_MNC !== selectedExtensionInfo?.EP_NgC?.ds?.pLMNId_MNC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>localAddress_ip_addr:</td>
-                                <td>1.1.1.5
+                                <td>localAddress_ip_addr</td>
+                                <td>{{ selectedExtensionInfo?.EP_NgC?.db?.localAddress_ip_addr }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>1.1.1.5</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.EP_NgC?.ds?.localAddress_ip_addr }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_NgC?.db?.localAddress_ip_addr === selectedExtensionInfo?.EP_NgC?.ds?.localAddress_ip_addr) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_NgC?.db?.localAddress_ip_addr !== selectedExtensionInfo?.EP_NgC?.ds?.localAddress_ip_addr">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>localAddress_vlan_id:</td>
-                                <td>1
+                                <td>localAddress_vlan_id</td>
+                                <td>{{ selectedExtensionInfo?.EP_NgC?.db?.localAddress_vlan_id }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>1</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.EP_NgC?.ds?.localAddress_vlan_id }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_NgC?.db?.localAddress_vlan_id === selectedExtensionInfo?.EP_NgC?.ds?.localAddress_vlan_id) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_NgC?.db?.localAddress_vlan_id !== selectedExtensionInfo?.EP_NgC?.ds?.localAddress_vlan_id">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>remoteAddress:</td>
-                                <td>1.1.2.5
+                                <td>remoteAddress</td>
+                                <td>{{ selectedExtensionInfo?.EP_NgC?.db?.remoteAddress }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>1.1.2.5</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.EP_NgC?.ds?.remoteAddress }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_NgC?.db?.remoteAddress === selectedExtensionInfo?.EP_NgC?.ds?.remoteAddress) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_NgC?.db?.remoteAddress !== selectedExtensionInfo?.EP_NgC?.ds?.remoteAddress">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                             </tbody>
                           </table>
@@ -1016,8 +1281,8 @@
                     </div>
                   </div>
 
-                  <!-- EP_NgU -->
-                  <div> 
+                  <!-- EP_NgU @2024/04/15 ok -->
+                  <div>
                     <span>EP_NgU</span>
                     <input id="EP_NgU" class="toggle" type="checkbox">
                     <label for="EP_NgU" class="lbl-toggle"></label>
@@ -1036,59 +1301,94 @@
                             </thead>
                             <tbody>
                               <tr>
-                                <td>gNBId:</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBId</td>
+                                <td>{{ selectedExtensionInfo?.EP_NgU?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_NgU?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_NgU?.db?.gNBId === selectedExtensionInfo?.EP_NgU?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_NgU?.db?.gNBId !== selectedExtensionInfo?.EP_NgU?.ds?.gNBId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>gNBIdLength:</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBIdLength</td>
+                                <td>{{ selectedExtensionInfo?.EP_NgU?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_NgU?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_NgU?.db?.gNBIdLength === selectedExtensionInfo?.EP_NgU?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_NgU?.db?.gNBIdLength !== selectedExtensionInfo?.EP_NgU?.ds?.gNBIdLength">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MCC:</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MCC</td>
+                                <td>{{ selectedExtensionInfo?.EP_NgU?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_NgU?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_NgU?.db?.pLMNId_MCC === selectedExtensionInfo?.EP_NgU?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_NgU?.db?.pLMNId_MCC !== selectedExtensionInfo?.EP_NgU?.ds?.pLMNId_MCC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MNC:</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MNC</td>
+                                <td>{{ selectedExtensionInfo?.EP_NgU?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_NgU?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_NgU?.db?.pLMNId_MNC === selectedExtensionInfo?.EP_NgU?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_NgU?.db?.pLMNId_MNC !== selectedExtensionInfo?.EP_NgU?.ds?.pLMNId_MNC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>localAddress_ip_addr:</td>
-                                <td>1.1.1.6
+                                <td>localAddress_ip_addr</td>
+                                <td>{{ selectedExtensionInfo?.EP_NgU?.db?.localAddress_ip_addr }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>1.1.1.6</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.EP_NgU?.ds?.localAddress_ip_addr }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_NgU?.db?.localAddress_ip_addr === selectedExtensionInfo?.EP_NgU?.ds?.localAddress_ip_addr) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_NgU?.db?.localAddress_ip_addr !== selectedExtensionInfo?.EP_NgU?.ds?.localAddress_ip_addr">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>localAddress_vlan_id:</td>
-                                <td>1
+                                <td>localAddress_vlan_id</td>
+                                <td>{{ selectedExtensionInfo?.EP_NgU?.db?.localAddress_vlan_id }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>1</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.EP_NgU?.ds?.localAddress_vlan_id }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_NgU?.db?.localAddress_vlan_id === selectedExtensionInfo?.EP_NgU?.ds?.localAddress_vlan_id) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_NgU?.db?.localAddress_vlan_id !== selectedExtensionInfo?.EP_NgU?.ds?.localAddress_vlan_id">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>remoteAddress:</td>
-                                <td>1.1.2.6
+                                <td>remoteAddress</td>
+                                <td>{{ selectedExtensionInfo?.EP_NgU?.db?.remoteAddress }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>1.1.2.6</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.EP_NgU?.ds?.remoteAddress }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_NgU?.db?.remoteAddress === selectedExtensionInfo?.EP_NgU?.ds?.remoteAddress) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_NgU?.db?.remoteAddress !== selectedExtensionInfo?.EP_NgU?.ds?.remoteAddress">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                             </tbody>
                           </table>
@@ -1097,7 +1397,7 @@
                     </div>
                   </div>
 
-                  <!-- NRCellCU -->
+                  <!-- NRCellCU @2024/04/15 ok -->
                   <div>
                     <span>NRCellCU</span>
                     <input id="NRCellCU" class="toggle" type="checkbox">
@@ -1117,57 +1417,92 @@
                             </thead>
                             <tbody>
                               <tr>
-                                <td>gNBId:</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBId</td>
+                                <td>{{ selectedExtensionInfo?.NRCellCU?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.NRCellCU?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRCellCU?.db?.gNBId === selectedExtensionInfo?.NRCellCU?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRCellCU?.db?.gNBId !== selectedExtensionInfo?.NRCellCU?.ds?.gNBId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>gNBIdLength:</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBIdLength</td>
+                                <td>{{ selectedExtensionInfo?.NRCellCU?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.NRCellCU?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRCellCU?.db?.gNBIdLength === selectedExtensionInfo?.NRCellCU?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRCellCU?.db?.gNBIdLength !== selectedExtensionInfo?.NRCellCU?.ds?.gNBIdLength">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MCC:</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MCC</td>
+                                <td>{{ selectedExtensionInfo?.NRCellCU?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.NRCellCU?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRCellCU?.db?.pLMNId_MCC === selectedExtensionInfo?.NRCellCU?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRCellCU?.db?.pLMNId_MCC !== selectedExtensionInfo?.NRCellCU?.ds?.pLMNId_MCC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MNC:</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MNC</td>
+                                <td>{{ selectedExtensionInfo?.NRCellCU?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.NRCellCU?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRCellCU?.db?.pLMNId_MNC === selectedExtensionInfo?.NRCellCU?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRCellCU?.db?.pLMNId_MNC !== selectedExtensionInfo?.NRCellCU?.ds?.pLMNId_MNC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>cellLocalId:</td>
-                                <td>100001000</td>
-                                <td>100001000</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>cellLocalId</td>
+                                <td>{{ selectedExtensionInfo?.NRCellCU?.db?.cellLocalId }}</td>
+                                <td>{{ selectedExtensionInfo?.NRCellCU?.ds?.cellLocalId }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRCellCU?.db?.cellLocalId === selectedExtensionInfo?.NRCellCU?.ds?.cellLocalId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRCellCU?.db?.cellLocalId !== selectedExtensionInfo?.NRCellCU?.ds?.cellLocalId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>absoluteFrequencySSB:</td>
-                                <td>100
+                                <td>absoluteFrequencySSB</td>
+                                <td>{{ selectedExtensionInfo?.NRCellCU?.db?.absoluteFrequencySSB }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>100</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.NRCellCU?.ds?.absoluteFrequencySSB }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRCellCU?.db?.absoluteFrequencySSB === selectedExtensionInfo?.NRCellCU?.ds?.absoluteFrequencySSB) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRCellCU?.db?.absoluteFrequencySSB !== selectedExtensionInfo?.NRCellCU?.ds?.absoluteFrequencySSB">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>sBSubCarrierSpacing:</td>
-                                <td>15
+                                <td>sSBSubCarrierSpacing</td>
+                                <td>{{ selectedExtensionInfo?.NRCellCU?.db?.sSBSubCarrierSpacing }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>15</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.NRCellCU?.ds?.sSBSubCarrierSpacing }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRCellCU?.db?.sSBSubCarrierSpacing === selectedExtensionInfo?.NRCellCU?.ds?.sSBSubCarrierSpacing) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRCellCU?.db?.sSBSubCarrierSpacing !== selectedExtensionInfo?.NRCellCU?.ds?.sSBSubCarrierSpacing">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                             </tbody>
                           </table>
@@ -1176,7 +1511,7 @@
                     </div>
                   </div>
 
-                  <!-- peeParametersList_NRCellCU -->
+                  <!-- peeParametersList_NRCellCU @2024/04/15 ok -->
                   <div>
                     <span>peeParametersList_NRCellCU</span>
                     <input id="peeParametersList_NRCellCU" class="toggle" type="checkbox">
@@ -1196,102 +1531,162 @@
                             </thead>
                             <tbody>
                               <tr>
-                                <td>gNBId:</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBId</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.gNBId === selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.gNBId !== selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.gNBId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>gNBIdLength:</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBIdLength</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.gNBIdLength === selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.gNBIdLength !== selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.gNBIdLength">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MCC:</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MCC</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.pLMNId_MCC === selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.pLMNId_MCC !== selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.pLMNId_MCC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MNC:</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MNC</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.pLMNId_MNC === selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.pLMNId_MNC !== selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.pLMNId_MNC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>cellLocalId:</td>
-                                <td>100001000</td>
-                                <td>100001000</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>cellLocalId</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.cellLocalId }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.cellLocalId }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.cellLocalId === selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.cellLocalId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.cellLocalId !== selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.cellLocalId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>siteIdentification:</td>
-                                <td>bbb
+                                <td>siteIdentification</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.siteIdentification }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>bbb</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.siteIdentification }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.siteIdentification === selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.siteIdentification) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.siteIdentification !== selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.siteIdentification">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>siteLatitude:</td>
-                                <td>10.0101
+                                <td>siteLatitude</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.siteLatitude }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>10.0101</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.siteLatitude }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.siteLatitude === selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.siteLatitude) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.siteLatitude !== selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.siteLatitude">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>siteLongitude:</td>
-                                <td>10.0101
+                                <td>siteLongitude</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.siteLongitude }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>10.0101</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.siteLongitude }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.siteLongitude === selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.siteLongitude) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.siteLongitude !== selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.siteLongitude">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>siteDescription:</td>
-                                <td>aaa
+                                <td>siteDescription</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.siteDescription }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>aaa</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.siteDescription }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.siteDescription === selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.siteDescription) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.siteDescription !== selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.siteDescription">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>equipmentType:</td>
-                                <td>RRU
+                                <td>equipmentType</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.equipmentType }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>RRU</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.equipmentType }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.equipmentType === selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.equipmentType) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.equipmentType !== selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.equipmentType">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>environmentType:</td>
-                                <td>Indoor
+                                <td>environmentType</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.environmentType }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>Indoor</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.environmentType }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.environmentType === selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.environmentType) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.environmentType !== selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.environmentType">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>powerInterface:</td>
-                                <td>AC
+                                <td>powerInterface</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.powerInterface }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>AC</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.powerInterface }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.powerInterface === selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.powerInterface) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRCellCU?.db?.powerInterface !== selectedExtensionInfo?.peeParametersList_NRCellCU?.ds?.powerInterface">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                             </tbody>
                           </table>
@@ -1300,7 +1695,7 @@
                     </div>
                   </div>
 
-                  <!-- vnfParametersList_NRCellCU -->
+                  <!-- vnfParametersList_NRCellCU @2024/04/15 ok -->
                   <div>
                     <span>vnfParametersList_NRCellCU</span>
                     <input id="vnfParametersList_NRCellCU" class="toggle" type="checkbox">
@@ -1320,75 +1715,120 @@
                             </thead>
                             <tbody>
                               <tr>
-                                <td>gNBId:</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBId</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.gNBId === selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.gNBId !== selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.gNBId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>gNBIdLength:</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBIdLength</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.gNBIdLength === selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.gNBIdLength !== selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.gNBIdLength">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MCC:</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MCC</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.pLMNId_MCC === selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.pLMNId_MCC !== selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.pLMNId_MCC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MNC:</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MNC</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.pLMNId_MNC === selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.pLMNId_MNC !== selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.pLMNId_MNC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>cellLocalId:</td>
-                                <td>100001000</td>
-                                <td>100001000</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>cellLocalId</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.cellLocalId }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.cellLocalId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.cellLocalId === selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.cellLocalId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.cellLocalId !== selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.cellLocalId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>autoScalable:</td>
-                                <td>true
+                                <td>autoScalable</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.autoScalable }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>true</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.autoScalable }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.autoScalable === selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.autoScalable) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.autoScalable !== selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.autoScalable">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>flavourId:</td>
-                                <td>1
+                                <td>flavourId</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.flavourId }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>1</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.flavourId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.flavourId === selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.flavourId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.flavourId !== selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.flavourId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>vnfInstanceId:</td>
-                                <td>1
+                                <td>vnfInstanceId</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.vnfInstanceId }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>1</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.vnfInstanceId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.vnfInstanceId === selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.vnfInstanceId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.vnfInstanceId !== selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.vnfInstanceId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>vnfId:</td>
-                                <td>1
+                                <td>vnfdId</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.vnfdId }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>1</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.vnfdId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.vnfdId === selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.vnfdId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRCellCU?.db?.vnfdId !== selectedExtensionInfo?.vnfParametersList_NRCellCU?.ds?.vnfdId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                             </tbody>
                           </table>
@@ -1397,7 +1837,7 @@
                     </div>
                   </div>
 
-                  <!-- s_NSSAI_leafList_NRCellCU -->
+                  <!-- s_NSSAI_leafList_NRCellCU @2024/04/15 ok -->
                   <div>
                     <span>s_NSSAI_leafList_NRCellCU</span>
                     <input id="s_NSSAI_leafList_NRCellCU" class="toggle" type="checkbox">
@@ -1417,48 +1857,78 @@
                             </thead>
                             <tbody>
                               <tr>
-                                <td>gNBId:</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBId</td>
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.db?.gNBId === selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.db?.gNBId !== selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.ds?.gNBId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>gNBIdLength:</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBIdLength</td>
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.db?.gNBIdLength === selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.db?.gNBIdLength !== selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.ds?.gNBIdLength">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MCC:</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MCC</td>
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.db?.pLMNId_MCC === selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.db?.pLMNId_MCC !== selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.ds?.pLMNId_MCC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MNC:</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MNC</td>
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.db?.pLMNId_MNC === selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.db?.pLMNId_MNC !== selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.ds?.pLMNId_MNC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>cellLocalId:</td>
-                                <td>100001000</td>
-                                <td>100001000</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>cellLocalId</td>
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.db?.cellLocalId }}</td>
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.ds?.cellLocalId }}</td>
+                                <td>{{ (selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.db?.cellLocalId === selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.ds?.cellLocalId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.db?.cellLocalId !== selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.ds?.cellLocalId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>s_NSSAi:</td>
-                                <td>0
+                                <td>s_NSSAI</td>
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.db?.s_NSSAI }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>0</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.ds?.s_NSSAI }}</td>
+                                <td>{{ (selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.db?.s_NSSAI === selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.ds?.s_NSSAI) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.db?.s_NSSAI !== selectedExtensionInfo?.s_NSSAI_leafList_NRCellCU?.ds?.s_NSSAI">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                             </tbody>
                           </table>
@@ -1467,7 +1937,7 @@
                     </div>
                   </div>
 
-                  <!-- gNBDUFunction -->
+                  <!-- gNBDUFunction @2024/04/15 ok -->
                   <div>
                     <span>gNBDUFunction</span>
                     <input id="gNBDUFunction" class="toggle" type="checkbox">
@@ -1487,48 +1957,78 @@
                             </thead>
                             <tbody>
                               <tr>
-                                <td>gNBId:</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBId</td>
+                                <td>{{ selectedExtensionInfo?.gNBDUFunction?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.gNBDUFunction?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.gNBDUFunction?.db?.gNBId === selectedExtensionInfo?.gNBDUFunction?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.gNBDUFunction?.db?.gNBId !== selectedExtensionInfo?.gNBDUFunction?.ds?.gNBId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>gNBIdLength:</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBIdLength</td>
+                                <td>{{ selectedExtensionInfo?.gNBDUFunction?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.gNBDUFunction?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.gNBDUFunction?.db?.gNBIdLength === selectedExtensionInfo?.gNBDUFunction?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.gNBDUFunction?.db?.gNBIdLength !== selectedExtensionInfo?.gNBDUFunction?.ds?.gNBIdLength">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MCC:</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MCC</td>
+                                <td>{{ selectedExtensionInfo?.gNBDUFunction?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.gNBDUFunction?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.gNBDUFunction?.db?.pLMNId_MCC === selectedExtensionInfo?.gNBDUFunction?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.gNBDUFunction?.db?.pLMNId_MCC !== selectedExtensionInfo?.gNBDUFunction?.ds?.pLMNId_MCC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MNC:</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MNC</td>
+                                <td>{{ selectedExtensionInfo?.gNBDUFunction?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.gNBDUFunction?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.gNBDUFunction?.db?.pLMNId_MNC === selectedExtensionInfo?.gNBDUFunction?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.gNBDUFunction?.db?.pLMNId_MNC !== selectedExtensionInfo?.gNBDUFunction?.ds?.pLMNId_MNC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>gNBDUId:</td>
-                                <td>11</td>
-                                <td>11</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBDUId</td>
+                                <td>{{ selectedExtensionInfo?.gNBDUFunction?.db?.gNBDUId }}</td>
+                                <td>{{ selectedExtensionInfo?.gNBDUFunction?.ds?.gNBDUId }}</td>
+                                <td>{{ (selectedExtensionInfo?.gNBDUFunction?.db?.gNBDUId === selectedExtensionInfo?.gNBDUFunction?.ds?.gNBDUId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.gNBDUFunction?.db?.gNBDUId !== selectedExtensionInfo?.gNBDUFunction?.ds?.gNBDUId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>gNBDUName:</td>
-                                <td>du1
+                                <td>gNBDUName</td>
+                                <td>{{ selectedExtensionInfo?.gNBDUFunction?.db?.gNBDUName }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>du1</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.gNBDUFunction?.ds?.gNBDUName }}</td>
+                                <td>{{ (selectedExtensionInfo?.gNBDUFunction?.db?.gNBDUName === selectedExtensionInfo?.gNBDUFunction?.ds?.gNBDUName) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.gNBDUFunction?.db?.gNBDUName !== selectedExtensionInfo?.gNBDUFunction?.ds?.gNBDUName">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                             </tbody>
                           </table>
@@ -1537,7 +2037,7 @@
                     </div>
                   </div>
 
-                  <!-- peeParametersList_DU -->
+                  <!-- peeParametersList_DU @2024/04/15 ok -->
                   <div>
                     <span>peeParametersList_DU</span>
                     <input id="peeParametersList_DU" class="toggle" type="checkbox">
@@ -1557,102 +2057,162 @@
                             </thead>
                             <tbody>
                               <tr>
-                                <td>gNBId:</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBId</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_DU?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_DU?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_DU?.db?.gNBId === selectedExtensionInfo?.peeParametersList_DU?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_DU?.db?.gNBId !== selectedExtensionInfo?.peeParametersList_DU?.ds?.gNBId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>gNBIdLength:</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBIdLength</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_DU?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_DU?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_DU?.db?.gNBIdLength === selectedExtensionInfo?.peeParametersList_DU?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_DU?.db?.gNBIdLength !== selectedExtensionInfo?.peeParametersList_DU?.ds?.gNBIdLength">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MCC:</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MCC</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_DU?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_DU?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_DU?.db?.pLMNId_MCC === selectedExtensionInfo?.peeParametersList_DU?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_DU?.db?.pLMNId_MCC !== selectedExtensionInfo?.peeParametersList_DU?.ds?.pLMNId_MCC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MNC:</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MNC</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_DU?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_DU?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_DU?.db?.pLMNId_MNC === selectedExtensionInfo?.peeParametersList_DU?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_DU?.db?.pLMNId_MNC !== selectedExtensionInfo?.peeParametersList_DU?.ds?.pLMNId_MNC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>gNBDUId:</td>
-                                <td>11</td>
-                                <td>11</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBDUId</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_DU?.db?.gNBDUId }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_DU?.ds?.gNBDUId }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_DU?.db?.gNBDUId === selectedExtensionInfo?.peeParametersList_DU?.ds?.gNBDUId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_DU?.db?.gNBDUId !== selectedExtensionInfo?.peeParametersList_DU?.ds?.gNBDUId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>siteIdentification:</td>
-                                <td>bbb
+                                <td>siteIdentification</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_DU?.db?.siteIdentification }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>bbb</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_DU?.ds?.siteIdentification }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_DU?.db?.siteIdentification === selectedExtensionInfo?.peeParametersList_DU?.ds?.siteIdentification) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_DU?.db?.siteIdentification !== selectedExtensionInfo?.peeParametersList_DU?.ds?.siteIdentification">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>siteLatitude:</td>
-                                <td>10.0202
+                                <td>siteLatitude</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_DU?.db?.siteLatitude }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>10.0202</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_DU?.ds?.siteLatitude }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_DU?.db?.siteLatitude === selectedExtensionInfo?.peeParametersList_DU?.ds?.siteLatitude) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_DU?.db?.siteLatitude !== selectedExtensionInfo?.peeParametersList_DU?.ds?.siteLatitude">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>siteLongitude:</td>
-                                <td>10.0202
+                                <td>siteLongitude</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_DU?.db?.siteLongitude }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>10.0202</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_DU?.ds?.siteLongitude }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_DU?.db?.siteLongitude === selectedExtensionInfo?.peeParametersList_DU?.ds?.siteLongitude) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_DU?.db?.siteLongitude !== selectedExtensionInfo?.peeParametersList_DU?.ds?.siteLongitude">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>siteDescription:</td>
-                                <td>aaa
+                                <td>siteDescription</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_DU?.db?.siteDescription }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>aaa</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_DU?.ds?.siteDescription }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_DU?.db?.siteDescription === selectedExtensionInfo?.peeParametersList_DU?.ds?.siteDescription) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_DU?.db?.siteDescription !== selectedExtensionInfo?.peeParametersList_DU?.ds?.siteDescription">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>equipmentType:</td>
-                                <td>RRU
+                                <td>equipmentType</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_DU?.db?.equipmentType }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>RRU</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_DU?.ds?.equipmentType }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_DU?.db?.equipmentType === selectedExtensionInfo?.peeParametersList_DU?.ds?.equipmentType) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_DU?.db?.equipmentType !== selectedExtensionInfo?.peeParametersList_DU?.ds?.equipmentType">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>environmentType:</td>
-                                <td>Indoor
+                                <td>environmentType</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_DU?.db?.environmentType }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>Indoor</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_DU?.ds?.environmentType }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_DU?.db?.environmentType === selectedExtensionInfo?.peeParametersList_DU?.ds?.environmentType) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_DU?.db?.environmentType !== selectedExtensionInfo?.peeParametersList_DU?.ds?.environmentType">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>powerInterface:</td>
-                                <td>AC
+                                <td>powerInterface</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_DU?.db?.powerInterface }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>AC</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_DU?.ds?.powerInterface }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_DU?.db?.powerInterface === selectedExtensionInfo?.peeParametersList_DU?.ds?.powerInterface) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_DU?.db?.powerInterface !== selectedExtensionInfo?.peeParametersList_DU?.ds?.powerInterface">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                             </tbody>
                           </table>
@@ -1661,7 +2221,7 @@
                     </div>
                   </div>
                   
-                  <!-- vnfParametersList_DU -->
+                  <!-- vnfParametersList_DU @2024/04/15 ok -->
                   <div>
                     <span>vnfParametersList_DU</span>
                     <input id="vnfParametersList_DU" class="toggle" type="checkbox">
@@ -1681,75 +2241,120 @@
                             </thead>
                             <tbody>
                               <tr>
-                                <td>gNBId:</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBId</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_DU?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_DU?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_DU?.db?.gNBId === selectedExtensionInfo?.vnfParametersList_DU?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_DU?.db?.gNBId !== selectedExtensionInfo?.vnfParametersList_DU?.ds?.gNBId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>gNBIdLength:</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBIdLength</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_DU?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_DU?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_DU?.db?.gNBIdLength === selectedExtensionInfo?.vnfParametersList_DU?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_DU?.db?.gNBIdLength !== selectedExtensionInfo?.vnfParametersList_DU?.ds?.gNBIdLength">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MCC:</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MCC</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_DU?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_DU?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_DU?.db?.pLMNId_MCC === selectedExtensionInfo?.vnfParametersList_DU?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_DU?.db?.pLMNId_MCC !== selectedExtensionInfo?.vnfParametersList_DU?.ds?.pLMNId_MCC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>pLMNId_MNC:</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>pLMNId_MNC</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_DU?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_DU?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_DU?.db?.pLMNId_MNC === selectedExtensionInfo?.vnfParametersList_DU?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_DU?.db?.pLMNId_MNC !== selectedExtensionInfo?.vnfParametersList_DU?.ds?.pLMNId_MNC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>gNBDUId:</td>
-                                <td>11</td>
-                                <td>11</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>gNBDUId</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_DU?.db?.gNBDUId }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_DU?.ds?.gNBDUId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_DU?.db?.gNBDUId === selectedExtensionInfo?.vnfParametersList_DU?.ds?.gNBDUId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_DU?.db?.gNBDUId !== selectedExtensionInfo?.vnfParametersList_DU?.ds?.gNBDUId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>autoScalable:</td>
-                                <td>true
+                                <td>autoScalable</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_DU?.db?.autoScalable }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>true</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_DU?.ds?.autoScalable }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_DU?.db?.autoScalable === selectedExtensionInfo?.vnfParametersList_DU?.ds?.autoScalable) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_DU?.db?.autoScalable !== selectedExtensionInfo?.vnfParametersList_DU?.ds?.autoScalable">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>flavourId:</td>
-                                <td>1
+                                <td>flavourId</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_DU?.db?.flavourId }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>1</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_DU?.ds?.flavourId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_DU?.db?.flavourId === selectedExtensionInfo?.vnfParametersList_DU?.ds?.flavourId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_DU?.db?.flavourId !== selectedExtensionInfo?.vnfParametersList_DU?.ds?.flavourId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>vnfInstanceId:</td>
-                                <td>1
+                                <td>vnfInstanceId</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_DU?.db?.vnfInstanceId }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>1</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_DU?.ds?.vnfInstanceId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_DU?.db?.vnfInstanceId === selectedExtensionInfo?.vnfParametersList_DU?.ds?.vnfInstanceId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_DU?.db?.vnfInstanceId !== selectedExtensionInfo?.vnfParametersList_DU?.ds?.vnfInstanceId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>vnfId:</td>
-                                <td>1
+                                <td>vnfdId</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_DU?.db?.vnfdId }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>1</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_DU?.ds?.vnfdId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_DU?.db?.vnfdId === selectedExtensionInfo?.vnfParametersList_DU?.ds?.vnfdId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_DU?.db?.vnfdId !== selectedExtensionInfo?.vnfParametersList_DU?.ds?.vnfdId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                             </tbody>
                           </table>
@@ -1758,187 +2363,11 @@
                     </div>
                   </div>
 
-                  <!-- EP_FIC_DU -->
+                  <!-- EP_F1C_DU @2024/04/15 ok -->
                   <div>
-                    <span>EP_FIC_DU</span>
-                    <input id="EP_FIC_DU" class="toggle" type="checkbox">
-                    <label for="EP_FIC_DU" class="lbl-toggle"></label>
-                    <div class="collapsible-content">
-                      <div class="content-inner">
-                        <div class="table basicParmType">
-                          <table>
-                            <thead>
-                              <tr>
-                                <th>Items</th>
-                                <th>Athena Ochestreator DB</th>
-                                <th>Network Element Datastore</th>
-                                <th>Conflict</th>
-                                <th>Action</th>
-                              </tr>
-                            </thead>
-                            <tbody>
-                              <tr>
-                                <td>gNBId:</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>gNBIdLength:</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>pLMNId_MCC:</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>pLMNId_MNC:</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>gNBDUId:</td>
-                                <td>11</td>
-                                <td>11</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>localAddress_ip_addr:</td>
-                                <td>1.1.2.1
-                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
-                                </td>
-                                <td>1.1.2.1</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>localAddress_vlan_id:</td>
-                                <td>1
-                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
-                                </td>
-                                <td>1</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>remoteAddress:</td>
-                                <td>1.1.1.1
-                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
-                                </td>
-                                <td>1.1.1.1</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                            </tbody>
-                          </table>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-
-                  <!-- EP_FIU_DU -->
-                  <div>
-                    <span>EP_FIU_DU</span>
-                    <input id="EP_FIU_DU" class="toggle" type="checkbox">
-                    <label for="EP_FIU_DU" class="lbl-toggle"></label>
-                    <div class="collapsible-content">
-                      <div class="content-inner">
-                        <div class="table basicParmType">
-                          <table>
-                            <thead>
-                              <tr>
-                                <th>Items</th>
-                                <th>Athena Ochestreator DB</th>
-                                <th>Network Element Datastore</th>
-                                <th>Conflict</th>
-                                <th>Action</th>
-                              </tr>
-                            </thead>
-                            <tbody>
-                              <tr>
-                                <td>gNBId:</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>gNBIdLength:</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>pLMNId_MCC:</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>pLMNId_MNC:</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>gNBDUId:</td>
-                                <td>11</td>
-                                <td>11</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>localAddress_ip_addr:</td>
-                                <td>1.1.2.3
-                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
-                                </td>
-                                <td>1.1.2.3</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>localAddress_vlan_id:</td>
-                                <td>1
-                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
-                                </td>
-                                <td>1</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>remoteAddress:</td>
-                                <td>1.1.1.3
-                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
-                                </td>
-                                <td>1.1.1.3</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                            </tbody>
-                          </table>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-
-                  <!-- NRCellDU -->
-                  <div>
-                    <span>NRCellDU</span>
-                    <input id="NRCellDU" class="toggle" type="checkbox">
-                    <label for="NRCellDU" class="lbl-toggle"></label>
+                    <span>EP_F1C_DU</span>
+                    <input id="EP_F1C_DU" class="toggle" type="checkbox">
+                    <label for="EP_F1C_DU" class="lbl-toggle"></label>
                     <div class="collapsible-content">
                       <div class="content-inner">
                         <div class="table basicParmType">
@@ -1955,171 +2384,105 @@
                             <tbody>
                               <tr>
                                 <td>gNBId</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_DU?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_DU?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1C_DU?.db?.gNBId === selectedExtensionInfo?.EP_F1C_DU?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1C_DU?.db?.gNBId !== selectedExtensionInfo?.EP_F1C_DU?.ds?.gNBId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>gNBIdLength</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_DU?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_DU?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1C_DU?.db?.gNBIdLength === selectedExtensionInfo?.EP_F1C_DU?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1C_DU?.db?.gNBIdLength !== selectedExtensionInfo?.EP_F1C_DU?.ds?.gNBIdLength">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MCC</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_DU?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_DU?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1C_DU?.db?.pLMNId_MCC === selectedExtensionInfo?.EP_F1C_DU?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1C_DU?.db?.pLMNId_MCC !== selectedExtensionInfo?.EP_F1C_DU?.ds?.pLMNId_MCC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MNC</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_DU?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_DU?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1C_DU?.db?.pLMNId_MNC === selectedExtensionInfo?.EP_F1C_DU?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1C_DU?.db?.pLMNId_MNC !== selectedExtensionInfo?.EP_F1C_DU?.ds?.pLMNId_MNC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>gNBDUId</td>
-                                <td>11</td>
-                                <td>11</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_DU?.db?.gNBDUId }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_DU?.ds?.gNBDUId }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1C_DU?.db?.gNBDUId === selectedExtensionInfo?.EP_F1C_DU?.ds?.gNBDUId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1C_DU?.db?.gNBDUId !== selectedExtensionInfo?.EP_F1C_DU?.ds?.gNBDUId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>cellLocalId</td>
-                                <td>100001000</td>
-                                <td>100001000</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>nRPCI</td>
-                                <td>100
+                                <td>localAddress_ip_addr</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_DU?.db?.localAddress_ip_addr }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>100</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_DU?.ds?.localAddress_ip_addr }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1C_DU?.db?.localAddress_ip_addr === selectedExtensionInfo?.EP_F1C_DU?.ds?.localAddress_ip_addr) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1C_DU?.db?.localAddress_ip_addr !== selectedExtensionInfo?.EP_F1C_DU?.ds?.localAddress_ip_addr">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>nRTAC</td>
-                                <td>3000
+                                <td>localAddress_vlan_id</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_DU?.db?.localAddress_vlan_id }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>3000</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_DU?.ds?.localAddress_vlan_id }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1C_DU?.db?.localAddress_vlan_id === selectedExtensionInfo?.EP_F1C_DU?.ds?.localAddress_vlan_id) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1C_DU?.db?.localAddress_vlan_id !== selectedExtensionInfo?.EP_F1C_DU?.ds?.localAddress_vlan_id">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>administrativeState</td>
-                                <td>Locked
+                                <td>remoteAddress</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_DU?.db?.remoteAddress }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>Locked</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>arfcnDL</td>
-                                <td>723333
-                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                <td>{{ selectedExtensionInfo?.EP_F1C_DU?.ds?.remoteAddress }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1C_DU?.db?.remoteAddress === selectedExtensionInfo?.EP_F1C_DU?.ds?.remoteAddress) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1C_DU?.db?.remoteAddress !== selectedExtensionInfo?.EP_F1C_DU?.ds?.remoteAddress">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
                                 </td>
-                                <td>723333</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>arfcnSUL</td>
-                                <td>2079415
-                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
-                                </td>
-                                <td>2079415</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>arfcnUL</td>
-                                <td>723333
-                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
-                                </td>
-                                <td>723333</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>bSChannelBwDL</td>
-                                <td>20
-                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
-                                </td>
-                                <td>20</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>bSChannelBwSUL</td>
-                                <td>1000
-                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
-                                </td>
-                                <td>1000</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>bSChannelBwUL</td>
-                                <td>1000
-                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
-                                </td>
-                                <td>1000</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>ssbFrequency</td>
-                                <td>9500
-                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
-                                </td>
-                                <td>9500</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>ssbPeriodicity</td>
-                                <td>5
-                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
-                                </td>
-                                <td>5</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>ssbSubCarrierSpacing</td>
-                                <td>15
-                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
-                                </td>
-                                <td>15</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>ssbOffset</td>
-                                <td>100
-                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
-                                </td>
-                                <td>100</td>
-                                <td>No</td>
-                                <td></td>
-                              </tr>
-                              <tr>
-                                <td>ssbDuration</td>
-                                <td>3
-                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
-                                </td>
-                                <td>3</td>
-                                <td>No</td>
-                                <td></td>
                               </tr>
                             </tbody>
                           </table>
@@ -2128,7 +2491,443 @@
                     </div>
                   </div>
 
-                  <!-- peeParametersList_NRCellDU -->
+                  <!-- EP_F1U_DU @2024/04/15 ok -->
+                  <div>
+                    <span>EP_F1U_DU</span>
+                    <input id="EP_F1U_DU" class="toggle" type="checkbox">
+                    <label for="EP_F1U_DU" class="lbl-toggle"></label>
+                    <div class="collapsible-content">
+                      <div class="content-inner">
+                        <div class="table basicParmType">
+                          <table>
+                            <thead>
+                              <tr>
+                                <th>Items</th>
+                                <th>Athena Ochestreator DB</th>
+                                <th>Network Element Datastore</th>
+                                <th>Conflict</th>
+                                <th>Action</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              <tr>
+                                <td>gNBId</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_DU?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_DU?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1U_DU?.db?.gNBId === selectedExtensionInfo?.EP_F1U_DU?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1U_DU?.db?.gNBId !== selectedExtensionInfo?.EP_F1U_DU?.ds?.gNBId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td>gNBIdLength</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_DU?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_DU?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1U_DU?.db?.gNBIdLength === selectedExtensionInfo?.EP_F1U_DU?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1U_DU?.db?.gNBIdLength !== selectedExtensionInfo?.EP_F1U_DU?.ds?.gNBIdLength">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td>pLMNId_MCC</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_DU?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_DU?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1U_DU?.db?.pLMNId_MCC === selectedExtensionInfo?.EP_F1U_DU?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1U_DU?.db?.pLMNId_MCC !== selectedExtensionInfo?.EP_F1U_DU?.ds?.pLMNId_MCC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td>pLMNId_MNC</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_DU?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_DU?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1U_DU?.db?.pLMNId_MNC === selectedExtensionInfo?.EP_F1U_DU?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1U_DU?.db?.pLMNId_MNC !== selectedExtensionInfo?.EP_F1U_DU?.ds?.pLMNId_MNC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td>gNBDUId</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_DU?.db?.gNBDUId }}</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_DU?.ds?.gNBDUId }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1U_DU?.db?.gNBDUId === selectedExtensionInfo?.EP_F1U_DU?.ds?.gNBDUId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1U_DU?.db?.gNBDUId !== selectedExtensionInfo?.EP_F1U_DU?.ds?.gNBDUId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td>localAddress_ip_addr</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_DU?.db?.localAddress_ip_addr }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_DU?.ds?.localAddress_ip_addr }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1U_DU?.db?.localAddress_ip_addr === selectedExtensionInfo?.EP_F1U_DU?.ds?.localAddress_ip_addr) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1U_DU?.db?.localAddress_ip_addr !== selectedExtensionInfo?.EP_F1U_DU?.ds?.localAddress_ip_addr">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td>localAddress_vlan_id</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_DU?.db?.localAddress_vlan_id }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_DU?.ds?.localAddress_vlan_id }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1U_DU?.db?.localAddress_vlan_id === selectedExtensionInfo?.EP_F1U_DU?.ds?.localAddress_vlan_id) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1U_DU?.db?.localAddress_vlan_id !== selectedExtensionInfo?.EP_F1U_DU?.ds?.localAddress_vlan_id">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td>remoteAddress</td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_DU?.db?.remoteAddress }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.EP_F1U_DU?.ds?.remoteAddress }}</td>
+                                <td>{{ (selectedExtensionInfo?.EP_F1U_DU?.db?.remoteAddress === selectedExtensionInfo?.EP_F1U_DU?.ds?.remoteAddress) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.EP_F1U_DU?.db?.remoteAddress !== selectedExtensionInfo?.EP_F1U_DU?.ds?.remoteAddress">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- NRCellDU @2024/04/15 ok -->
+                  <div>
+                    <span>NRCellDU</span>
+                    <input id="NRCellDU" class="toggle" type="checkbox">
+                      <label for="NRCellDU" class="lbl-toggle"></label>
+                      <div class="collapsible-content">
+                        <div class="content-inner">
+                          <div class="table basicParmType">
+                            <table>
+                              <thead>
+                                <tr>
+                                  <th>Items</th>
+                                  <th>Athena Ochestreator DB</th>
+                                  <th>Network Element Datastore</th>
+                                  <th>Conflict</th>
+                                  <th>Action</th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                <tr>
+                                  <td>gNBId</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.db?.gNBId }}</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.ds?.gNBId }}</td>
+                                  <td>{{ (selectedExtensionInfo?.NRCellDU?.db?.gNBId === selectedExtensionInfo?.NRCellDU?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                  <td>
+                                    <span *ngIf="selectedExtensionInfo?.NRCellDU?.db?.gNBId !== selectedExtensionInfo?.NRCellDU?.ds?.gNBId">
+                                      <button>DB → gNB</button>
+                                      <button>DB ← gNB</button>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>gNBIdLength</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.db?.gNBIdLength }}</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.ds?.gNBIdLength }}</td>
+                                  <td>{{ (selectedExtensionInfo?.NRCellDU?.db?.gNBIdLength === selectedExtensionInfo?.NRCellDU?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                  <td>
+                                    <span *ngIf="selectedExtensionInfo?.NRCellDU?.db?.gNBIdLength !== selectedExtensionInfo?.NRCellDU?.ds?.gNBIdLength">
+                                      <button>DB → gNB</button>
+                                      <button>DB ← gNB</button>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>pLMNId_MCC</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.db?.pLMNId_MCC }}</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.ds?.pLMNId_MCC }}</td>
+                                  <td>{{ (selectedExtensionInfo?.NRCellDU?.db?.pLMNId_MCC === selectedExtensionInfo?.NRCellDU?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                  <td>
+                                    <span *ngIf="selectedExtensionInfo?.NRCellDU?.db?.pLMNId_MCC !== selectedExtensionInfo?.NRCellDU?.ds?.pLMNId_MCC">
+                                      <button>DB → gNB</button>
+                                      <button>DB ← gNB</button>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>pLMNId_MNC</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.db?.pLMNId_MNC }}</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.ds?.pLMNId_MNC }}</td>
+                                  <td>{{ (selectedExtensionInfo?.NRCellDU?.db?.pLMNId_MNC === selectedExtensionInfo?.NRCellDU?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                  <td>
+                                    <span *ngIf="selectedExtensionInfo?.NRCellDU?.db?.pLMNId_MNC !== selectedExtensionInfo?.NRCellDU?.ds?.pLMNId_MNC">
+                                      <button>DB → gNB</button>
+                                      <button>DB ← gNB</button>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>gNBDUId</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.db?.gNBDUId }}</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.ds?.gNBDUId }}</td>
+                                  <td>{{ (selectedExtensionInfo?.NRCellDU?.db?.gNBDUId === selectedExtensionInfo?.NRCellDU?.ds?.gNBDUId) ? 'No' : 'Yes' }}</td>
+                                  <td>
+                                    <span *ngIf="selectedExtensionInfo?.NRCellDU?.db?.gNBDUId !== selectedExtensionInfo?.NRCellDU?.ds?.gNBDUId">
+                                      <button>DB → gNB</button>
+                                      <button>DB ← gNB</button>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>cellLocalId</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.db?.cellLocalId }}</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.ds?.cellLocalId }}</td>
+                                  <td>{{ (selectedExtensionInfo?.NRCellDU?.db?.cellLocalId === selectedExtensionInfo?.NRCellDU?.ds?.cellLocalId) ? 'No' : 'Yes' }}</td>
+                                  <td>
+                                    <span *ngIf="selectedExtensionInfo?.NRCellDU?.db?.cellLocalId !== selectedExtensionInfo?.NRCellDU?.ds?.cellLocalId">
+                                      <button>DB → gNB</button>
+                                      <button>DB ← gNB</button>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>nRPCI</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.db?.nRPCI }}
+                                  
+                                    <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                  </td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.ds?.nRPCI }}</td>
+                                  <td>{{ (selectedExtensionInfo?.NRCellDU?.db?.nRPCI === selectedExtensionInfo?.NRCellDU?.ds?.nRPCI) ? 'No' : 'Yes' }}</td>
+                                  <td>
+                                    <span *ngIf="selectedExtensionInfo?.NRCellDU?.db?.nRPCI !== selectedExtensionInfo?.NRCellDU?.ds?.nRPCI">
+                                      <button>DB → gNB</button>
+                                      <button>DB ← gNB</button>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>nRTAC</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.db?.nRTAC }}
+                                  
+                                    <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                  </td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.ds?.nRTAC }}</td>
+                                  <td>{{ (selectedExtensionInfo?.NRCellDU?.db?.nRTAC === selectedExtensionInfo?.NRCellDU?.ds?.nRTAC) ? 'No' : 'Yes' }}</td>
+                                  <td>
+                                    <span *ngIf="selectedExtensionInfo?.NRCellDU?.db?.nRTAC !== selectedExtensionInfo?.NRCellDU?.ds?.nRTAC">
+                                      <button>DB → gNB</button>
+                                      <button>DB ← gNB</button>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>administrativeState</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.db?.administrativeState }}
+                                  
+                                    <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                  </td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.ds?.administrativeState }}</td>
+                                  <td>{{ (selectedExtensionInfo?.NRCellDU?.db?.administrativeState === selectedExtensionInfo?.NRCellDU?.ds?.administrativeState) ? 'No' : 'Yes' }}</td>
+                                  <td>
+                                    <span *ngIf="selectedExtensionInfo?.NRCellDU?.db?.administrativeState !== selectedExtensionInfo?.NRCellDU?.ds?.administrativeState">
+                                      <button>DB → gNB</button>
+                                      <button>DB ← gNB</button>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>arfcnDL</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.db?.arfcnDL }}
+                                  
+                                    <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                  </td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.ds?.arfcnDL }}</td>
+                                  <td>{{ (selectedExtensionInfo?.NRCellDU?.db?.arfcnDL === selectedExtensionInfo?.NRCellDU?.ds?.arfcnDL) ? 'No' : 'Yes' }}</td>
+                                  <td>
+                                    <span *ngIf="selectedExtensionInfo?.NRCellDU?.db?.arfcnDL !== selectedExtensionInfo?.NRCellDU?.ds?.arfcnDL">
+                                      <button>DB → gNB</button>
+                                      <button>DB ← gNB</button>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>arfcnUL</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.db?.arfcnUL }}
+                                  
+                                    <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                  </td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.ds?.arfcnUL }}</td>
+                                  <td>{{ (selectedExtensionInfo?.NRCellDU?.db?.arfcnUL === selectedExtensionInfo?.NRCellDU?.ds?.arfcnUL) ? 'No' : 'Yes' }}</td>
+                                  <td>
+                                    <span *ngIf="selectedExtensionInfo?.NRCellDU?.db?.arfcnUL !== selectedExtensionInfo?.NRCellDU?.ds?.arfcnUL">
+                                      <button>DB → gNB</button>
+                                      <button>DB ← gNB</button>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>arfcnSUL</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.db?.arfcnSUL }}
+                                  
+                                    <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                  </td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.ds?.arfcnSUL }}</td>
+                                  <td>{{ (selectedExtensionInfo?.NRCellDU?.db?.arfcnSUL === selectedExtensionInfo?.NRCellDU?.ds?.arfcnSUL) ? 'No' : 'Yes' }}</td>
+                                  <td>
+                                    <span *ngIf="selectedExtensionInfo?.NRCellDU?.db?.arfcnSUL !== selectedExtensionInfo?.NRCellDU?.ds?.arfcnSUL">
+                                      <button>DB → gNB</button>
+                                      <button>DB ← gNB</button>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>bSChannelBwDL</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.db?.bSChannelBwDL }}
+                                  
+                                    <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                  </td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.ds?.bSChannelBwDL }}</td>
+                                  <td>{{ (selectedExtensionInfo?.NRCellDU?.db?.bSChannelBwDL === selectedExtensionInfo?.NRCellDU?.ds?.bSChannelBwDL) ? 'No' : 'Yes' }}</td>
+                                  <td>
+                                    <span *ngIf="selectedExtensionInfo?.NRCellDU?.db?.bSChannelBwDL !== selectedExtensionInfo?.NRCellDU?.ds?.bSChannelBwDL">
+                                      <button>DB → gNB</button>
+                                      <button>DB ← gNB</button>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>bSChannelBwUL</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.db?.bSChannelBwUL }}
+                                  
+                                    <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                  </td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.ds?.bSChannelBwUL }}</td>
+                                  <td>{{ (selectedExtensionInfo?.NRCellDU?.db?.bSChannelBwUL === selectedExtensionInfo?.NRCellDU?.ds?.bSChannelBwUL) ? 'No' : 'Yes' }}</td>
+                                  <td>
+                                    <span *ngIf="selectedExtensionInfo?.NRCellDU?.db?.bSChannelBwUL !== selectedExtensionInfo?.NRCellDU?.ds?.bSChannelBwUL">
+                                      <button>DB → gNB</button>
+                                      <button>DB ← gNB</button>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>bSChannelBwSUL</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.db?.bSChannelBwSUL }}
+                                  
+                                    <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                  </td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.ds?.bSChannelBwSUL }}</td>
+                                  <td>{{ (selectedExtensionInfo?.NRCellDU?.db?.bSChannelBwSUL === selectedExtensionInfo?.NRCellDU?.ds?.bSChannelBwSUL) ? 'No' : 'Yes' }}</td>
+                                  <td>
+                                    <span *ngIf="selectedExtensionInfo?.NRCellDU?.db?.bSChannelBwSUL !== selectedExtensionInfo?.NRCellDU?.ds?.bSChannelBwSUL">
+                                      <button>DB → gNB</button>
+                                      <button>DB ← gNB</button>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>ssbFrequency</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.db?.ssbFrequency }}
+                                  
+                                    <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                  </td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.ds?.ssbFrequency }}</td>
+                                  <td>{{ (selectedExtensionInfo?.NRCellDU?.db?.ssbFrequency === selectedExtensionInfo?.NRCellDU?.ds?.ssbFrequency) ? 'No' : 'Yes' }}</td>
+                                  <td>
+                                    <span *ngIf="selectedExtensionInfo?.NRCellDU?.db?.ssbFrequency !== selectedExtensionInfo?.NRCellDU?.ds?.ssbFrequency">
+                                      <button>DB → gNB</button>
+                                      <button>DB ← gNB</button>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>ssbPeriodicity</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.db?.ssbPeriodicity }}
+                                  
+                                    <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                  </td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.ds?.ssbPeriodicity }}</td>
+                                  <td>{{ (selectedExtensionInfo?.NRCellDU?.db?.ssbPeriodicity === selectedExtensionInfo?.NRCellDU?.ds?.ssbPeriodicity) ? 'No' : 'Yes' }}</td>
+                                  <td>
+                                    <span *ngIf="selectedExtensionInfo?.NRCellDU?.db?.ssbPeriodicity !== selectedExtensionInfo?.NRCellDU?.ds?.ssbPeriodicity">
+                                      <button>DB → gNB</button>
+                                      <button>DB ← gNB</button>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>ssbSubCarrierSpacing</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.db?.ssbSubCarrierSpacing }}
+                                  
+                                    <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                  </td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.ds?.ssbSubCarrierSpacing }}</td>
+                                  <td>{{ (selectedExtensionInfo?.NRCellDU?.db?.ssbSubCarrierSpacing === selectedExtensionInfo?.NRCellDU?.ds?.ssbSubCarrierSpacing) ? 'No' : 'Yes' }}</td>
+                                  <td>
+                                    <span *ngIf="selectedExtensionInfo?.NRCellDU?.db?.ssbSubCarrierSpacing !== selectedExtensionInfo?.NRCellDU?.ds?.ssbSubCarrierSpacing">
+                                      <button>DB → gNB</button>
+                                      <button>DB ← gNB</button>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>ssbOffset</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.db?.ssbOffset }}
+                                  
+                                    <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                  </td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.ds?.ssbOffset }}</td>
+                                  <td>{{ (selectedExtensionInfo?.NRCellDU?.db?.ssbOffset === selectedExtensionInfo?.NRCellDU?.ds?.ssbOffset) ? 'No' : 'Yes' }}</td>
+                                  <td>
+                                    <span *ngIf="selectedExtensionInfo?.NRCellDU?.db?.ssbOffset !== selectedExtensionInfo?.NRCellDU?.ds?.ssbOffset">
+                                      <button>DB → gNB</button>
+                                      <button>DB ← gNB</button>
+                                    </span>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>ssbDuration</td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.db?.ssbDuration }}
+                                  
+                                    <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                  </td>
+                                  <td>{{ selectedExtensionInfo?.NRCellDU?.ds?.ssbDuration }}</td>
+                                  <td>{{ (selectedExtensionInfo?.NRCellDU?.db?.ssbDuration === selectedExtensionInfo?.NRCellDU?.ds?.ssbDuration) ? 'No' : 'Yes' }}</td>
+                                  <td>
+                                    <span *ngIf="selectedExtensionInfo?.NRCellDU?.db?.ssbDuration !== selectedExtensionInfo?.NRCellDU?.ds?.ssbDuration">
+                                      <button>DB → gNB</button>
+                                      <button>DB ← gNB</button>
+                                    </span>
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                          </div>
+                        </div>
+                      </div>
+                  </div>
+
+                  <!-- peeParametersList_NRCellDU @2024/04/15 ok -->
                   <div>
                     <span>peeParametersList_NRCellDU</span>
                     <input id="peeParametersList_NRCellDU" class="toggle" type="checkbox">
@@ -2149,108 +2948,173 @@
                             <tbody>
                               <tr>
                                 <td>gNBId</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.gNBId === selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.gNBId !== selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.gNBId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>gNBIdLength</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.gNBIdLength === selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.gNBIdLength !== selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.gNBIdLength">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MCC</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.pLMNId_MCC === selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.pLMNId_MCC !== selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.pLMNId_MCC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MNC</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.pLMNId_MNC === selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.pLMNId_MNC !== selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.pLMNId_MNC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>gNBDUId</td>
-                                <td>11</td>
-                                <td>11</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.gNBDUId }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.gNBDUId }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.gNBDUId === selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.gNBDUId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.gNBDUId !== selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.gNBDUId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>cellLocalId</td>
-                                <td>100001000</td>
-                                <td>100001000</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.cellLocalId }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.cellLocalId }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.cellLocalId === selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.cellLocalId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.cellLocalId !== selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.cellLocalId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>siteIdentification</td>
-                                <td>bbb
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.siteIdentification }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>bbb</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.siteIdentification }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.siteIdentification === selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.siteIdentification) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.siteIdentification !== selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.siteIdentification">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>siteLatitude</td>
-                                <td>10.0303
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.siteLatitude }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>10.0303</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.siteLatitude }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.siteLatitude === selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.siteLatitude) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.siteLatitude !== selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.siteLatitude">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>siteLongitude</td>
-                                <td>10.3033
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.siteLongitude }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>10.3033</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.siteLongitude }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.siteLongitude === selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.siteLongitude) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.siteLongitude !== selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.siteLongitude">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>siteDescription</td>
-                                <td>aaa
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.siteDescription }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>aaa</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.siteDescription }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.siteDescription === selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.siteDescription) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.siteDescription !== selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.siteDescription">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>equipmentType</td>
-                                <td>RRU
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.equipmentType }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>RRU</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.equipmentType }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.equipmentType === selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.equipmentType) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.equipmentType !== selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.equipmentType">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>environmentType</td>
-                                <td>Indoor
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.environmentType }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>Indoor</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.environmentType }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.environmentType === selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.environmentType) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.environmentType !== selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.environmentType">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>powerInterface</td>
-                                <td>AC
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.powerInterface }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>AC</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.powerInterface }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.powerInterface === selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.powerInterface) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRCellDU?.db?.powerInterface !== selectedExtensionInfo?.peeParametersList_NRCellDU?.ds?.powerInterface">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                             </tbody>
                           </table>
@@ -2259,7 +3123,7 @@
                     </div>
                   </div>
 
-                  <!-- vnfParametersList_NRCellDU -->
+                  <!-- vnfParametersList_NRCellDU @2024/04/15 ok -->
                   <div>
                     <span>vnfParametersList_NRCellDU</span>
                     <input id="vnfParametersList_NRCellDU" class="toggle" type="checkbox">
@@ -2280,81 +3144,131 @@
                             <tbody>
                               <tr>
                                 <td>gNBId</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.gNBId === selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.gNBId !== selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.gNBId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>gNBIdLength</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.gNBIdLength === selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.gNBIdLength !== selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.gNBIdLength">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MCC</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.pLMNId_MCC === selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.pLMNId_MCC !== selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.pLMNId_MCC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MNC</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.pLMNId_MNC === selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.pLMNId_MNC !== selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.pLMNId_MNC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>gNBDUId</td>
-                                <td>11</td>
-                                <td>11</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.gNBDUId }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.gNBDUId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.gNBDUId === selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.gNBDUId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.gNBDUId !== selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.gNBDUId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>cellLocalId</td>
-                                <td>100001000</td>
-                                <td>100001000</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.cellLocalId }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.cellLocalId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.cellLocalId === selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.cellLocalId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.cellLocalId !== selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.cellLocalId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>autoScalable</td>
-                                <td>true
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.autoScalable }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>true</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.autoScalable }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.autoScalable === selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.autoScalable) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.autoScalable !== selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.autoScalable">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>flavourId</td>
-                                <td>1
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.flavourId }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>1</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.flavourId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.flavourId === selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.flavourId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.flavourId !== selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.flavourId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>vnfInstanceId</td>
-                                <td>1
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.vnfInstanceId }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>1</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.vnfInstanceId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.vnfInstanceId === selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.vnfInstanceId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.vnfInstanceId !== selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.vnfInstanceId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>vnfId</td>
-                                <td>1
+                                <td>vnfdId</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.vnfdId }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>1</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.vnfdId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.vnfdId === selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.vnfdId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRCellDU?.db?.vnfdId !== selectedExtensionInfo?.vnfParametersList_NRCellDU?.ds?.vnfdId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                             </tbody>
                           </table>
@@ -2363,7 +3277,7 @@
                     </div>
                   </div>
 
-                  <!-- s_NSSAI_leafList_NRCellDU -->
+                  <!-- s_NSSAI_leafList_NRCellDU @2024/04/15 ok -->
                   <div>
                     <span>s_NSSAI_leafList_NRCellDU</span>
                     <input id="s_NSSAI_leafList_NRCellDU" class="toggle" type="checkbox">
@@ -2384,54 +3298,89 @@
                             <tbody>
                               <tr>
                                 <td>gNBId</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.db?.gNBId === selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.db?.gNBId !== selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.ds?.gNBId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>gNBIdLength</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.db?.gNBIdLength === selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.db?.gNBIdLength !== selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.ds?.gNBIdLength">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MCC</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.db?.pLMNId_MCC === selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.db?.pLMNId_MCC !== selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.ds?.pLMNId_MCC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MNC</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.db?.pLMNId_MNC === selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.db?.pLMNId_MNC !== selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.ds?.pLMNId_MNC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>gNBDUId</td>
-                                <td>11</td>
-                                <td>11</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.db?.gNBDUId }}</td>
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.ds?.gNBDUId }}</td>
+                                <td>{{ (selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.db?.gNBDUId === selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.ds?.gNBDUId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.db?.gNBDUId !== selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.ds?.gNBDUId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>cellLocalId</td>
-                                <td>100001000</td>
-                                <td>100001000</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.db?.cellLocalId }}</td>
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.ds?.cellLocalId }}</td>
+                                <td>{{ (selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.db?.cellLocalId === selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.ds?.cellLocalId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.db?.cellLocalId !== selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.ds?.cellLocalId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>s_NSSAI</td>
-                                <td>0
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.db?.s_NSSAI }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>0</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.ds?.s_NSSAI }}</td>
+                                <td>{{ (selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.db?.s_NSSAI === selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.ds?.s_NSSAI) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.db?.s_NSSAI !== selectedExtensionInfo?.s_NSSAI_leafList_NRCellDU?.ds?.s_NSSAI">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                             </tbody>
                           </table>
@@ -2440,7 +3389,7 @@
                     </div>
                   </div>
 
-                  <!-- NRSectorCarrierRef_NRCellDU -->
+                  <!-- NRSectorCarrierRef_NRCellDU @2024/04/15 ok -->
                   <div>
                     <span>NRSectorCarrierRef_NRCellDU</span>
                     <input id="NRSectorCarrierRef_NRCellDU" class="toggle" type="checkbox">
@@ -2461,54 +3410,89 @@
                             <tbody>
                               <tr>
                                 <td>gNBId</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.db?.gNBId === selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.db?.gNBId !== selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.ds?.gNBId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>gNBIdLength</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.db?.gNBIdLength === selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.db?.gNBIdLength !== selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.ds?.gNBIdLength">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MCC</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.db?.pLMNId_MCC === selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.db?.pLMNId_MCC !== selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.ds?.pLMNId_MCC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MNC</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.db?.pLMNId_MNC === selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.db?.pLMNId_MNC !== selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.ds?.pLMNId_MNC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>gNBDUId</td>
-                                <td>11</td>
-                                <td>11</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.db?.gNBDUId }}</td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.ds?.gNBDUId }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.db?.gNBDUId === selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.ds?.gNBDUId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.db?.gNBDUId !== selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.ds?.gNBDUId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>cellLocalId</td>
-                                <td>100001000</td>
-                                <td>100001000</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.db?.cellLocalId }}</td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.ds?.cellLocalId }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.db?.cellLocalId === selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.ds?.cellLocalId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.db?.cellLocalId !== selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.ds?.cellLocalId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>NRSectorCarrierRef</td>
-                                <td>0
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.db?.NRSectorCarrierRef }}
                                   <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
                                 </td>
-                                <td>0</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.ds?.NRSectorCarrierRef }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.db?.NRSectorCarrierRef === selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.ds?.NRSectorCarrierRef) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.db?.NRSectorCarrierRef !== selectedExtensionInfo?.NRSectorCarrierRef_NRCellDU?.ds?.NRSectorCarrierRef">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                             </tbody>
                           </table>
@@ -2517,7 +3501,7 @@
                     </div>
                   </div>
 
-                  <!-- bWPRef_leafList_NRCellDU -->
+                  <!-- bWPRef_leafList_NRCellDU @2024/04/15 ok -->
                   <div>
                     <span>bWPRef_leafList_NRCellDU</span>
                     <input id="bWPRef_leafList_NRCellDU" class="toggle" type="checkbox">
@@ -2538,52 +3522,89 @@
                             <tbody>
                               <tr>
                                 <td>gNBId</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.db?.gNBId === selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.db?.gNBId !== selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.ds?.gNBId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>gNBIdLength</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.db?.gNBIdLength === selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.db?.gNBIdLength !== selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.ds?.gNBIdLength">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MCC</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.db?.pLMNId_MCC === selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.db?.pLMNId_MCC !== selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.ds?.pLMNId_MCC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MNC</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.db?.pLMNId_MNC === selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.db?.pLMNId_MNC !== selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.ds?.pLMNId_MNC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>gNBDUId</td>
-                                <td>11</td>
-                                <td>11</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.db?.gNBDUId }}</td>
+                                <td>{{ selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.ds?.gNBDUId }}</td>
+                                <td>{{ (selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.db?.gNBDUId === selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.ds?.gNBDUId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.db?.gNBDUId !== selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.ds?.gNBDUId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>cellLocalId</td>
-                                <td>100001000</td>
-                                <td>100001000</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.db?.cellLocalId }}</td>
+                                <td>{{ selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.ds?.cellLocalId }}</td>
+                                <td>{{ (selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.db?.cellLocalId === selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.ds?.cellLocalId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.db?.cellLocalId !== selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.ds?.cellLocalId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>bWPRef</td>
-                                <td>0 <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>0</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.db?.bWPRef }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.ds?.bWPRef }}</td>
+                                <td>{{ (selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.db?.bWPRef === selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.ds?.bWPRef) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.db?.bWPRef !== selectedExtensionInfo?.bWPRef_leafList_NRCellDU?.ds?.bWPRef">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                             </tbody>
                           </table>
@@ -2592,7 +3613,7 @@
                     </div>
                   </div>
                   
-                  <!-- NRSectorCarrier -->
+                  <!-- NRSectorCarrier @2024/04/15 ok -->
                   <div>
                     <span>NRSectorCarrier</span>
                     <input id="NRSectorCarrier" class="toggle" type="checkbox">
@@ -2613,87 +3634,161 @@
                             <tbody>
                               <tr>
                                 <td>gNBId</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrier?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrier?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRSectorCarrier?.db?.gNBId === selectedExtensionInfo?.NRSectorCarrier?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRSectorCarrier?.db?.gNBId !== selectedExtensionInfo?.NRSectorCarrier?.ds?.gNBId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>gNBIdLength</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrier?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrier?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRSectorCarrier?.db?.gNBIdLength === selectedExtensionInfo?.NRSectorCarrier?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRSectorCarrier?.db?.gNBIdLength !== selectedExtensionInfo?.NRSectorCarrier?.ds?.gNBIdLength">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MCC</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrier?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrier?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRSectorCarrier?.db?.pLMNId_MCC === selectedExtensionInfo?.NRSectorCarrier?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRSectorCarrier?.db?.pLMNId_MCC !== selectedExtensionInfo?.NRSectorCarrier?.ds?.pLMNId_MCC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MNC</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrier?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrier?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRSectorCarrier?.db?.pLMNId_MNC === selectedExtensionInfo?.NRSectorCarrier?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRSectorCarrier?.db?.pLMNId_MNC !== selectedExtensionInfo?.NRSectorCarrier?.ds?.pLMNId_MNC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>gNBDUId</td>
-                                <td>11</td>
-                                <td>11</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrier?.db?.gNBDUId }}</td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrier?.ds?.gNBDUId }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRSectorCarrier?.db?.gNBDUId === selectedExtensionInfo?.NRSectorCarrier?.ds?.gNBDUId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRSectorCarrier?.db?.gNBDUId !== selectedExtensionInfo?.NRSectorCarrier?.ds?.gNBDUId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>arfcnDL</td>
-                                <td>649788 <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>649788</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrier?.db?.arfcnDL }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrier?.ds?.arfcnDL }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRSectorCarrier?.db?.arfcnDL === selectedExtensionInfo?.NRSectorCarrier?.ds?.arfcnDL) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRSectorCarrier?.db?.arfcnDL !== selectedExtensionInfo?.NRSectorCarrier?.ds?.arfcnDL">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>arfcnUL</td>
-                                <td>649788 <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>649788</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrier?.db?.arfcnUL }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrier?.ds?.arfcnUL }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRSectorCarrier?.db?.arfcnUL === selectedExtensionInfo?.NRSectorCarrier?.ds?.arfcnUL) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRSectorCarrier?.db?.arfcnUL !== selectedExtensionInfo?.NRSectorCarrier?.ds?.arfcnUL">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>bSChannelBwDL</td>
-                                <td>100 <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>100</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrier?.db?.bSChannelBwDL }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrier?.ds?.bSChannelBwDL }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRSectorCarrier?.db?.bSChannelBwDL === selectedExtensionInfo?.NRSectorCarrier?.ds?.bSChannelBwDL) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRSectorCarrier?.db?.bSChannelBwDL !== selectedExtensionInfo?.NRSectorCarrier?.ds?.bSChannelBwDL">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>bSChannelBwUL</td>
-                                <td>100 <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>100</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrier?.db?.bSChannelBwUL }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrier?.ds?.bSChannelBwUL }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRSectorCarrier?.db?.bSChannelBwUL === selectedExtensionInfo?.NRSectorCarrier?.ds?.bSChannelBwUL) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRSectorCarrier?.db?.bSChannelBwUL !== selectedExtensionInfo?.NRSectorCarrier?.ds?.bSChannelBwUL">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>txDirection</td>
-                                <td>DL <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>DL</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrier?.db?.txDirection }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrier?.ds?.txDirection }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRSectorCarrier?.db?.txDirection === selectedExtensionInfo?.NRSectorCarrier?.ds?.txDirection) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRSectorCarrier?.db?.txDirection !== selectedExtensionInfo?.NRSectorCarrier?.ds?.txDirection">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>configuredMaxTxPower</td>
-                                <td>9 <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>10</td>
-                                <td>Yes</td>
-                                <td><button>DB → gNB</button><button>DB ← gNB</button></td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrier?.db?.configuredMaxTxPower }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrier?.ds?.configuredMaxTxPower }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRSectorCarrier?.db?.configuredMaxTxPower === selectedExtensionInfo?.NRSectorCarrier?.ds?.configuredMaxTxPower) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRSectorCarrier?.db?.configuredMaxTxPower !== selectedExtensionInfo?.NRSectorCarrier?.ds?.configuredMaxTxPower">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>configuredMaxTxEIRP</td>
-                                <td>10 <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>10</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrier?.db?.configuredMaxTxEIRP }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.NRSectorCarrier?.ds?.configuredMaxTxEIRP }}</td>
+                                <td>{{ (selectedExtensionInfo?.NRSectorCarrier?.db?.configuredMaxTxEIRP === selectedExtensionInfo?.NRSectorCarrier?.ds?.configuredMaxTxEIRP) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.NRSectorCarrier?.db?.configuredMaxTxEIRP !== selectedExtensionInfo?.NRSectorCarrier?.ds?.configuredMaxTxEIRP">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                             </tbody>
                           </table>
@@ -2702,7 +3797,7 @@
                     </div>
                   </div>
 
-                  <!-- peeParametersList_NRSector -->
+                  <!-- peeParametersList_NRSector @2024/04/15 ok -->
                   <div>
                     <span>peeParametersList_NRSector</span>
                     <input id="peeParametersList_NRSector" class="toggle" type="checkbox">
@@ -2723,87 +3818,161 @@
                             <tbody>
                               <tr>
                                 <td>gNBId</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRSector?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRSector?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRSector?.db?.gNBId === selectedExtensionInfo?.peeParametersList_NRSector?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRSector?.db?.gNBId !== selectedExtensionInfo?.peeParametersList_NRSector?.ds?.gNBId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>gNBIdLength</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRSector?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRSector?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRSector?.db?.gNBIdLength === selectedExtensionInfo?.peeParametersList_NRSector?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRSector?.db?.gNBIdLength !== selectedExtensionInfo?.peeParametersList_NRSector?.ds?.gNBIdLength">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MCC</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRSector?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRSector?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRSector?.db?.pLMNId_MCC === selectedExtensionInfo?.peeParametersList_NRSector?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRSector?.db?.pLMNId_MCC !== selectedExtensionInfo?.peeParametersList_NRSector?.ds?.pLMNId_MCC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MNC</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRSector?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRSector?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRSector?.db?.pLMNId_MNC === selectedExtensionInfo?.peeParametersList_NRSector?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRSector?.db?.pLMNId_MNC !== selectedExtensionInfo?.peeParametersList_NRSector?.ds?.pLMNId_MNC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>gNBDUId</td>
-                                <td>11</td>
-                                <td>11</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRSector?.db?.gNBDUId }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRSector?.ds?.gNBDUId }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRSector?.db?.gNBDUId === selectedExtensionInfo?.peeParametersList_NRSector?.ds?.gNBDUId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRSector?.db?.gNBDUId !== selectedExtensionInfo?.peeParametersList_NRSector?.ds?.gNBDUId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>siteIdentification</td>
-                                <td>bbb<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>bbb</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRSector?.db?.siteIdentification }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRSector?.ds?.siteIdentification }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRSector?.db?.siteIdentification === selectedExtensionInfo?.peeParametersList_NRSector?.ds?.siteIdentification) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRSector?.db?.siteIdentification !== selectedExtensionInfo?.peeParametersList_NRSector?.ds?.siteIdentification">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>siteLatitude</td>
-                                <td>10.1111 <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>10.1111</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRSector?.db?.siteLatitude }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRSector?.ds?.siteLatitude }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRSector?.db?.siteLatitude === selectedExtensionInfo?.peeParametersList_NRSector?.ds?.siteLatitude) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRSector?.db?.siteLatitude !== selectedExtensionInfo?.peeParametersList_NRSector?.ds?.siteLatitude">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>siteLongitude</td>
-                                <td>10.2222 <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>10.2222</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRSector?.db?.siteLongitude }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRSector?.ds?.siteLongitude }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRSector?.db?.siteLongitude === selectedExtensionInfo?.peeParametersList_NRSector?.ds?.siteLongitude) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRSector?.db?.siteLongitude !== selectedExtensionInfo?.peeParametersList_NRSector?.ds?.siteLongitude">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>siteDescription</td>
-                                <td>aaa<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>aaa</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRSector?.db?.siteDescription }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRSector?.ds?.siteDescription }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRSector?.db?.siteDescription === selectedExtensionInfo?.peeParametersList_NRSector?.ds?.siteDescription) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRSector?.db?.siteDescription !== selectedExtensionInfo?.peeParametersList_NRSector?.ds?.siteDescription">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>equipmentType</td>
-                                <td>RRU<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>RRU</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRSector?.db?.equipmentType }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRSector?.ds?.equipmentType }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRSector?.db?.equipmentType === selectedExtensionInfo?.peeParametersList_NRSector?.ds?.equipmentType) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRSector?.db?.equipmentType !== selectedExtensionInfo?.peeParametersList_NRSector?.ds?.equipmentType">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>environmentType</td>
-                                <td>Indoor<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>Indoor</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRSector?.db?.environmentType }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRSector?.ds?.environmentType }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRSector?.db?.environmentType === selectedExtensionInfo?.peeParametersList_NRSector?.ds?.environmentType) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRSector?.db?.environmentType !== selectedExtensionInfo?.peeParametersList_NRSector?.ds?.environmentType">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>powerInterface</td>
-                                <td>AC<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>AC</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRSector?.db?.powerInterface }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_NRSector?.ds?.powerInterface }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_NRSector?.db?.powerInterface === selectedExtensionInfo?.peeParametersList_NRSector?.ds?.powerInterface) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.peeParametersList_NRSector?.db?.powerInterface !== selectedExtensionInfo?.peeParametersList_NRSector?.ds?.powerInterface">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                             </tbody>
                           </table>
@@ -2812,7 +3981,7 @@
                     </div>
                   </div>
 
-                  <!-- vnfParametersList_NRSector -->
+                  <!-- vnfParametersList_NRSector @2024/04/15 ok -->
                   <div>
                     <span>vnfParametersList_NRSector</span>
                     <input id="vnfParametersList_NRSector" class="toggle" type="checkbox">
@@ -2833,59 +4002,107 @@
                             <tbody>
                               <tr>
                                 <td>gNBId</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRSector?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRSector?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRSector?.db?.gNBId === selectedExtensionInfo?.vnfParametersList_NRSector?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRSector?.db?.gNBId !== selectedExtensionInfo?.vnfParametersList_NRSector?.ds?.gNBId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>gNBIdLength</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRSector?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRSector?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRSector?.db?.gNBIdLength === selectedExtensionInfo?.vnfParametersList_NRSector?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRSector?.db?.gNBIdLength !== selectedExtensionInfo?.vnfParametersList_NRSector?.ds?.gNBIdLength">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MCC</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRSector?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRSector?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRSector?.db?.pLMNId_MCC === selectedExtensionInfo?.vnfParametersList_NRSector?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRSector?.db?.pLMNId_MCC !== selectedExtensionInfo?.vnfParametersList_NRSector?.ds?.pLMNId_MCC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MNC</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRSector?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRSector?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRSector?.db?.pLMNId_MNC === selectedExtensionInfo?.vnfParametersList_NRSector?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRSector?.db?.pLMNId_MNC !== selectedExtensionInfo?.vnfParametersList_NRSector?.ds?.pLMNId_MNC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>autoScalable</td>
-                                <td>true<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>true</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRSector?.db?.autoScalable }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRSector?.ds?.autoScalable }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRSector?.db?.autoScalable === selectedExtensionInfo?.vnfParametersList_NRSector?.ds?.autoScalable) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRSector?.db?.autoScalable !== selectedExtensionInfo?.vnfParametersList_NRSector?.ds?.autoScalable">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>flavourId</td>
-                                <td>1<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>1</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRSector?.db?.flavourId }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRSector?.ds?.flavourId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRSector?.db?.flavourId === selectedExtensionInfo?.vnfParametersList_NRSector?.ds?.flavourId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRSector?.db?.flavourId !== selectedExtensionInfo?.vnfParametersList_NRSector?.ds?.flavourId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>vnfInstanceId</td>
-                                <td>1<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>1</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRSector?.db?.vnfInstanceId }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRSector?.ds?.vnfInstanceId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRSector?.db?.vnfInstanceId === selectedExtensionInfo?.vnfParametersList_NRSector?.ds?.vnfInstanceId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRSector?.db?.vnfInstanceId !== selectedExtensionInfo?.vnfParametersList_NRSector?.ds?.vnfInstanceId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>vnfdId</td>
-                                <td>1<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>1</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRSector?.db?.vnfdId }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_NRSector?.ds?.vnfdId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_NRSector?.db?.vnfdId === selectedExtensionInfo?.vnfParametersList_NRSector?.ds?.vnfdId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.vnfParametersList_NRSector?.db?.vnfdId !== selectedExtensionInfo?.vnfParametersList_NRSector?.ds?.vnfdId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                             </tbody>
                           </table>
@@ -2894,7 +4111,7 @@
                     </div>
                   </div>
 
-                  <!-- BWP -->
+                  <!-- BWP @2024/04/15 ok -->
                   <div>
                     <span>BWP</span>
                     <input id="BWP" class="toggle" type="checkbox">
@@ -2915,80 +4132,147 @@
                             <tbody>
                               <tr>
                                 <td>gNBId</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.BWP?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.BWP?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.BWP?.db?.gNBId === selectedExtensionInfo?.BWP?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.BWP?.db?.gNBId !== selectedExtensionInfo?.BWP?.ds?.gNBId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>gNBIdLength</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.BWP?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.BWP?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.BWP?.db?.gNBIdLength === selectedExtensionInfo?.BWP?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.BWP?.db?.gNBIdLength !== selectedExtensionInfo?.BWP?.ds?.gNBIdLength">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MCC</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.BWP?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.BWP?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.BWP?.db?.pLMNId_MCC === selectedExtensionInfo?.BWP?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.BWP?.db?.pLMNId_MCC !== selectedExtensionInfo?.BWP?.ds?.pLMNId_MCC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MNC</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.BWP?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.BWP?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.BWP?.db?.pLMNId_MNC === selectedExtensionInfo?.BWP?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.BWP?.db?.pLMNId_MNC !== selectedExtensionInfo?.BWP?.ds?.pLMNId_MNC">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>gNBDUId</td>
-                                <td>11</td>
-                                <td>11</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.BWP?.db?.gNBDUId }}</td>
+                                <td>{{ selectedExtensionInfo?.BWP?.ds?.gNBDUId }}</td>
+                                <td>{{ (selectedExtensionInfo?.BWP?.db?.gNBDUId === selectedExtensionInfo?.BWP?.ds?.gNBDUId) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.BWP?.db?.gNBDUId !== selectedExtensionInfo?.BWP?.ds?.gNBDUId">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>bwpContext</td>
-                                <td>DL<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>DL</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.BWP?.db?.bwpContext }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.BWP?.ds?.bwpContext }}</td>
+                                <td>{{ (selectedExtensionInfo?.BWP?.db?.bwpContext === selectedExtensionInfo?.BWP?.ds?.bwpContext) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.BWP?.db?.bwpContext !== selectedExtensionInfo?.BWP?.ds?.bwpContext">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>isInitialBwp</td>
-                                <td>INITIAL<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>INITIAL</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.BWP?.db?.isInitialBwp }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.BWP?.ds?.isInitialBwp }}</td>
+                                <td>{{ (selectedExtensionInfo?.BWP?.db?.isInitialBwp === selectedExtensionInfo?.BWP?.ds?.isInitialBwp) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.BWP?.db?.isInitialBwp !== selectedExtensionInfo?.BWP?.ds?.isInitialBwp">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>subCarrierSpacing</td>
-                                <td>15<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>15</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.BWP?.db?.subCarrierSpacing }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.BWP?.ds?.subCarrierSpacing }}</td>
+                                <td>{{ (selectedExtensionInfo?.BWP?.db?.subCarrierSpacing === selectedExtensionInfo?.BWP?.ds?.subCarrierSpacing) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.BWP?.db?.subCarrierSpacing !== selectedExtensionInfo?.BWP?.ds?.subCarrierSpacing">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>cyclicPrefix</td>
-                                <td>Normal<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>Normal</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.BWP?.db?.cyclicPrefix }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.BWP?.ds?.cyclicPrefix }}</td>
+                                <td>{{ (selectedExtensionInfo?.BWP?.db?.cyclicPrefix === selectedExtensionInfo?.BWP?.ds?.cyclicPrefix) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.BWP?.db?.cyclicPrefix !== selectedExtensionInfo?.BWP?.ds?.cyclicPrefix">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
                                 <td>startRB</td>
-                                <td>1<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>1</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>{{ selectedExtensionInfo?.BWP?.db?.startRB }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.BWP?.ds?.startRB }}</td>
+                                <td>{{ (selectedExtensionInfo?.BWP?.db?.startRB === selectedExtensionInfo?.BWP?.ds?.startRB) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.BWP?.db?.startRB !== selectedExtensionInfo?.BWP?.ds?.startRB">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                               <tr>
-                                <td>numberOfrRBs</td>
-                                <td>25<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>25</td>
-                                <td>No</td>
-                                <td></td>
+                                <td>numberOfRBs</td>
+                                <td>{{ selectedExtensionInfo?.BWP?.db?.numberOfRBs }}
+                                  <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon>
+                                </td>
+                                <td>{{ selectedExtensionInfo?.BWP?.ds?.numberOfRBs }}</td>
+                                <td>{{ (selectedExtensionInfo?.BWP?.db?.numberOfRBs === selectedExtensionInfo?.BWP?.ds?.numberOfRBs) ? 'No' : 'Yes' }}</td>
+                                <td>
+                                  <span *ngIf="selectedExtensionInfo?.BWP?.db?.numberOfRBs !== selectedExtensionInfo?.BWP?.ds?.numberOfRBs">
+                                    <button>DB → gNB</button>
+                                    <button>DB ← gNB</button>
+                                  </span>
+                                </td>
                               </tr>
                             </tbody>
                           </table>
@@ -2997,7 +4281,7 @@
                     </div>
                   </div>
 
-                  <!-- peeParametersList_BWP -->
+                  <!-- peeParametersList_BWP @2024/04/15 ok -->
                   <div>
                     <span>peeParametersList_BWP</span>
                     <input id="peeParametersList_BWP" class="toggle" type="checkbox">
@@ -3018,86 +4302,86 @@
                             <tbody>
                               <tr>
                                 <td>gNBId</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_BWP?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_BWP?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_BWP?.db?.gNBId === selectedExtensionInfo?.peeParametersList_BWP?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
                                 <td></td>
                               </tr>
                               <tr>
                                 <td>gNBIdLength</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_BWP?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_BWP?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_BWP?.db?.gNBIdLength === selectedExtensionInfo?.peeParametersList_BWP?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
                                 <td></td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MCC</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_BWP?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_BWP?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_BWP?.db?.pLMNId_MCC === selectedExtensionInfo?.peeParametersList_BWP?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
                                 <td></td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MNC</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_BWP?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_BWP?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_BWP?.db?.pLMNId_MNC === selectedExtensionInfo?.peeParametersList_BWP?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
                                 <td></td>
                               </tr>
                               <tr>
                                 <td>gNBDUId</td>
-                                <td>11</td>
-                                <td>11</td>
-                                <td>No</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_BWP?.db?.gNBDUId }}</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_BWP?.ds?.gNBDUId }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_BWP?.db?.gNBDUId === selectedExtensionInfo?.peeParametersList_BWP?.ds?.gNBDUId) ? 'No' : 'Yes' }}</td>
                                 <td></td>
                               </tr>
                               <tr>
                                 <td>siteIdentification</td>
-                                <td>bbb<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>bbb</td>
-                                <td>No</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_BWP?.db?.siteIdentification }}<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_BWP?.ds?.siteIdentification }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_BWP?.db?.siteIdentification === selectedExtensionInfo?.peeParametersList_BWP?.ds?.siteIdentification) ? 'No' : 'Yes' }}</td>
                                 <td></td>
                               </tr>
                               <tr>
                                 <td>siteLatitude</td>
-                                <td>10.3333<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>10.3333</td>
-                                <td>No</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_BWP?.db?.siteLatitude }}<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_BWP?.ds?.siteLatitude }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_BWP?.db?.siteLatitude === selectedExtensionInfo?.peeParametersList_BWP?.ds?.siteLatitude) ? 'No' : 'Yes' }}</td>
                                 <td></td>
                               </tr>
                               <tr>
                                 <td>siteLongitude</td>
-                                <td>10.4444<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>10.4444</td>
-                                <td>No</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_BWP?.db?.siteLongitude }}<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_BWP?.ds?.siteLongitude }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_BWP?.db?.siteLongitude === selectedExtensionInfo?.peeParametersList_BWP?.ds?.siteLongitude) ? 'No' : 'Yes' }}</td>
                                 <td></td>
                               </tr>
                               <tr>
                                 <td>siteDescription</td>
-                                <td>aaa<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>aaa</td>
-                                <td>No</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_BWP?.db?.siteDescription }}<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_BWP?.ds?.siteDescription }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_BWP?.db?.siteDescription === selectedExtensionInfo?.peeParametersList_BWP?.ds?.siteDescription) ? 'No' : 'Yes' }}</td>
                                 <td></td>
                               </tr>
                               <tr>
                                 <td>equipmentType</td>
-                                <td>RRU<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>RRU</td>
-                                <td>No</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_BWP?.db?.equipmentType }}<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_BWP?.ds?.equipmentType }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_BWP?.db?.equipmentType === selectedExtensionInfo?.peeParametersList_BWP?.ds?.equipmentType) ? 'No' : 'Yes' }}</td>
                                 <td></td>
                               </tr>
                               <tr>
                                 <td>environmentType</td>
-                                <td>Indoor<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>Indoor</td>
-                                <td>No</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_BWP?.db?.environmentType }}<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_BWP?.ds?.environmentType }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_BWP?.db?.environmentType === selectedExtensionInfo?.peeParametersList_BWP?.ds?.environmentType) ? 'No' : 'Yes' }}</td>
                                 <td></td>
                               </tr>
                               <tr>
                                 <td>powerInterface</td>
-                                <td>AC<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>AC</td>
-                                <td>No</td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_BWP?.db?.powerInterface }}<mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
+                                <td>{{ selectedExtensionInfo?.peeParametersList_BWP?.ds?.powerInterface }}</td>
+                                <td>{{ (selectedExtensionInfo?.peeParametersList_BWP?.db?.powerInterface === selectedExtensionInfo?.peeParametersList_BWP?.ds?.powerInterface) ? 'No' : 'Yes' }}</td>
                                 <td></td>
                               </tr>
                             </tbody>
@@ -3107,7 +4391,7 @@
                     </div>
                   </div>
 
-                  <!-- vnfParametersList_BWP -->
+                  <!-- vnfParametersList_BWP @2024/04/15 ok -->
                   <div>
                     <span>vnfParametersList_BWP</span>
                     <input id="vnfParametersList_BWP" class="toggle" type="checkbox">
@@ -3128,58 +4412,58 @@
                             <tbody>
                               <tr>
                                 <td>gNBId</td>
-                                <td>2</td>
-                                <td>2</td>
-                                <td>No</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_BWP?.db?.gNBId }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_BWP?.ds?.gNBId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_BWP?.db?.gNBId === selectedExtensionInfo?.vnfParametersList_BWP?.ds?.gNBId) ? 'No' : 'Yes' }}</td>
                                 <td></td>
                               </tr>
                               <tr>
                                 <td>gNBIdLength</td>
-                                <td>22</td>
-                                <td>22</td>
-                                <td>No</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_BWP?.db?.gNBIdLength }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_BWP?.ds?.gNBIdLength }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_BWP?.db?.gNBIdLength === selectedExtensionInfo?.vnfParametersList_BWP?.ds?.gNBIdLength) ? 'No' : 'Yes' }}</td>
                                 <td></td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MCC</td>
-                                <td>466</td>
-                                <td>466</td>
-                                <td>No</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_BWP?.db?.pLMNId_MCC }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_BWP?.ds?.pLMNId_MCC }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_BWP?.db?.pLMNId_MCC === selectedExtensionInfo?.vnfParametersList_BWP?.ds?.pLMNId_MCC) ? 'No' : 'Yes' }}</td>
                                 <td></td>
                               </tr>
                               <tr>
                                 <td>pLMNId_MNC</td>
-                                <td>55</td>
-                                <td>55</td>
-                                <td>No</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_BWP?.db?.pLMNId_MNC }}</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_BWP?.ds?.pLMNId_MNC }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_BWP?.db?.pLMNId_MNC === selectedExtensionInfo?.vnfParametersList_BWP?.ds?.pLMNId_MNC) ? 'No' : 'Yes' }}</td>
                                 <td></td>
                               </tr>
                               <tr>
                                 <td>autoScalable</td>
-                                <td>true <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>true</td>
-                                <td>No</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_BWP?.db?.autoScalable }} <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_BWP?.ds?.autoScalable }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_BWP?.db?.autoScalable === selectedExtensionInfo?.vnfParametersList_BWP?.ds?.autoScalable) ? 'No' : 'Yes' }}</td>
                                 <td></td>
                               </tr>
                               <tr>
                                 <td>flavourId</td>
-                                <td>1 <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>1</td>
-                                <td>No</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_BWP?.db?.flavourId }} <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_BWP?.ds?.flavourId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_BWP?.db?.flavourId === selectedExtensionInfo?.vnfParametersList_BWP?.ds?.flavourId) ? 'No' : 'Yes' }}</td>
                                 <td></td>
                               </tr>
                               <tr>
                                 <td>vnfInstanceId</td>
-                                <td>1 <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>1</td>
-                                <td>No</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_BWP?.db?.vnfInstanceId }} <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_BWP?.ds?.vnfInstanceId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_BWP?.db?.vnfInstanceId === selectedExtensionInfo?.vnfParametersList_BWP?.ds?.vnfInstanceId) ? 'No' : 'Yes' }}</td>
                                 <td></td>
                               </tr>
                               <tr>
-                                <td>vnfId</td>
-                                <td>1 <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
-                                <td>1</td>
-                                <td>No</td>
+                                <td>vnfdId</td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_BWP?.db?.vnfdId }} <mat-icon tooltip="{{languageService.i18n['BS.edit']}}">edit</mat-icon></td>
+                                <td>{{ selectedExtensionInfo?.vnfParametersList_BWP?.ds?.vnfdId }}</td>
+                                <td>{{ (selectedExtensionInfo?.vnfParametersList_BWP?.db?.vnfdId === selectedExtensionInfo?.vnfParametersList_BWP?.ds?.vnfdId) ? 'No' : 'Yes' }}</td>
                                 <td></td>
                               </tr>
                             </tbody>

--- a/src/app/bs-management/bs-info/bs-info.component.ts
+++ b/src/app/bs-management/bs-info/bs-info.component.ts
@@ -19,7 +19,7 @@ import { ParsePositionPipe } from '../../shared/pipes/position-parser.pipe'; // 
 import { apiForBSMgmt } from '../../shared/api/For_BS_Mgmt'; // @2024/03/25 Add
 
 // 引入儲存各個資訊所需的 interfaces
-import { BSInfo, Components }                      from '../../shared/interfaces/BS/For_queryBsInfo_BS';       // @2024/03/25 Add
+import { BSInfo, Components, ExtensionInfo }       from '../../shared/interfaces/BS/For_queryBsInfo_BS';       // @2024/03/25 Add
 import { ForUpdateBs }                             from '../../shared/interfaces/BS/For_updateBs';             // @2024/04/14 Add
 import { BSInfo_dist, Info_dist, Components_dist } from '../../shared/interfaces/BS/For_queryBsInfo_dist_BS';  // @2024/03/25 Add
 import { ForUpdateDistributedBs, Cellinfo_dist }   from '../../shared/interfaces/BS/For_updateDistributedBs';  // @2024/04/14 Add
@@ -203,6 +203,36 @@ export class BSInfoComponent implements OnInit {
                   '\nLog type displayed after tab switch:', this.bsParametersType );
   }
 
+  nciList: string[] = []; // 存儲NCI列表
+  selectedNci: string = ''; // 當前選擇的NCI
+  selectedExtensionInfo: ExtensionInfo | undefined; // 當前選擇的ExtensionInfo
+
+  onSelectedNciChange() {
+    if (this.bsType === '1' && this.selectBsInfo) {
+      this.selectedExtensionInfo = this.selectBsInfo.extension_info.find(info => info.nci === this.selectedNci); // 更新當前選擇的ExtensionInfo
+    } else if (this.bsType === '2' && this.selectBsInfo_dist) {
+      this.selectedExtensionInfo = this.selectBsInfo_dist.extension_info.find(info => info.nci === this.selectedNci); // 更新當前選擇的ExtensionInfo
+    }
+  }
+
+  onSearchClick() {
+    if (this.bsType === '1' && this.selectBsInfo) {
+      this.selectedExtensionInfo = this.selectBsInfo.extension_info.find(info => info.nci === this.selectedNci);
+    } else if (this.bsType === '2' && this.selectBsInfo_dist) {
+      this.selectedExtensionInfo = this.selectBsInfo_dist.extension_info.find(info => info.nci === this.selectedNci);
+    }
+  }
+  
+  onClearClick() {
+    if (this.bsType === '1' && this.selectBsInfo) {
+      this.selectedNci = this.nciList[0];
+      this.selectedExtensionInfo = this.selectBsInfo.extension_info.find(info => info.nci === this.selectedNci);
+    } else if (this.bsType === '2' && this.selectBsInfo_dist) {
+      this.selectedNci = this.nciList[0];
+      this.selectedExtensionInfo = this.selectBsInfo_dist.extension_info.find(info => info.nci === this.selectedNci);
+    }
+  }
+
 // ↑ For Bs Parameters Page Control @2024/03/29 Add ↑
 
 
@@ -216,7 +246,18 @@ export class BSInfoComponent implements OnInit {
    selectBsPosition: string = "";                     // 用於存儲當前選中的一體式 BS 位置
   selectDistBsPosition: string = "";                  // 用於存儲當前選中的分佈式 BS 位置
   
-  // 用於獲取基站資訊 @2024/04/12 Update - 更新計算分佈式 Cell 數方式，改跟基站主頁方法相同
+  /**
+   * @2024/04/15 Update
+   * 取得基站資訊
+   * @method getQueryBsInfo
+   * @description
+   * - 用於獲取基站資訊，依據是本地模式或API模式，來自Local文件或服務器
+   * - 處理一體式與分佈式基站的不同數據結構
+   * @note
+   * - 這個函數同時處理兩種類型的基站資訊，根據基站類型計算相應的 Cell 數量
+   * - @2024/04/12 Update - 更新計算分佈式 Cell 數方式，改跟基站主頁方法相同
+   * - @2024/04/15 Add - 新增"基站參數"欄位所需的設值處理
+   */
   getQueryBsInfo() {
     console.log( 'getQueryBsInfo() - Start' );
 
@@ -273,6 +314,18 @@ export class BSInfoComponent implements OnInit {
 
       this.isLoadingBsInfo = false; // Local 模式下，數據加載快速完成，直接設置為 false
 
+      // @2024/04/15 Add
+      // 獲取 NCI 列表並設定預設選擇的 NCI 和 ExtensionInfo
+      if (this.bsType === "1" && this.selectBsInfo) {
+        this.nciList = this.selectBsInfo.extension_info.map(info => info.nci);
+        this.selectedNci = this.nciList[0];
+        this.selectedExtensionInfo = this.selectBsInfo.extension_info.find(info => info.nci === this.selectedNci);
+      } else if (this.bsType === "2" && this.selectBsInfo_dist) {
+        this.nciList = this.selectBsInfo_dist.extension_info.map(info => info.nci);
+        this.selectedNci = this.nciList[0];
+        this.selectedExtensionInfo = this.selectBsInfo_dist.extension_info.find(info => info.nci === this.selectedNci);
+      }
+
     } else {
       
       // 非 Local 模式: 通過 API 從服務器獲取數據
@@ -327,6 +380,18 @@ export class BSInfoComponent implements OnInit {
           //this.getNEList(); 
 
           this.isLoadingBsInfo = false; // 數據加載完成
+
+          // @2024/04/15 Add
+          // 獲取 NCI 列表並設定預設選擇的 NCI 和 ExtensionInfo
+          if (res.bstype === 1 && this.selectBsInfo) {
+            this.nciList = this.selectBsInfo.extension_info.map(info => info.nci);
+            this.selectedNci = this.nciList[0];
+            this.selectedExtensionInfo = this.selectBsInfo.extension_info.find(info => info.nci === this.selectedNci);
+          } else if (res.bstype === 2 && this.selectBsInfo_dist) {
+            this.nciList = this.selectBsInfo_dist.extension_info.map(info => info.nci);
+            this.selectedNci = this.nciList[0];
+            this.selectedExtensionInfo = this.selectBsInfo_dist.extension_info.find(info => info.nci === this.selectedNci);
+          }
         },
         error: ( error ) => {
           console.error( 'Error fetching BS info:', error );
@@ -1136,6 +1201,18 @@ export class BSInfoComponent implements OnInit {
 
 // ↑ 繪製拓樸圖區 @2024/03/28 Add ↑
   
+
+
+
+
+
+
+
+
+
+
+
+
 
 // ↓ 網元列表區 @2024/03/29 Add ↓
 

--- a/src/app/shared/models/spinner/spinner.component.html
+++ b/src/app/shared/models/spinner/spinner.component.html
@@ -1,0 +1,7 @@
+<ngx-spinner
+  bdColor="rgba(51,51,51,0.5)"
+  size="medium"
+  color="#fff"
+  type="ball-scale-multiple">
+  <p style="font-size: 20px; color: white">Processing...</p>
+</ngx-spinner>

--- a/src/app/shared/models/spinner/spinner.component.scss
+++ b/src/app/shared/models/spinner/spinner.component.scss
@@ -1,0 +1,9 @@
+:host ::ng-deep .loading-text button {
+  background-color: #3d86ab;
+  border: 1px solid #6ba1cf;
+  color: #fff;
+  border-radius: 5px;
+  padding: 0.3em 1em;
+  margin: 0 0 0 0.7em;
+  cursor: pointer;
+}

--- a/src/app/shared/models/spinner/spinner.component.spec.ts
+++ b/src/app/shared/models/spinner/spinner.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SpinnerComponent } from './spinner.component';
+
+describe('SpinnerComponent', () => {
+  let component: SpinnerComponent;
+  let fixture: ComponentFixture<SpinnerComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SpinnerComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SpinnerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/models/spinner/spinner.component.ts
+++ b/src/app/shared/models/spinner/spinner.component.ts
@@ -1,0 +1,35 @@
+import { Component, OnDestroy } from '@angular/core';
+import { BaseService } from 'src/app/service/base.service';
+import { NgxSpinnerService } from 'ngx-spinner';
+import { Subscription } from 'rxjs';
+import { HttpClient } from '@angular/common/http';
+
+@Component({
+  selector: 'app-spinner',
+  templateUrl: './spinner.component.html',
+  styleUrls: ['./spinner.component.scss']
+})
+export class SpinnerComponent implements OnDestroy {
+  cancelScpt: Subscription;
+
+  constructor(
+    public spinner: NgxSpinnerService,
+    public baseService: BaseService,
+    public http: HttpClient
+  ) {
+
+  }
+
+  ngOnDestroy() {
+    if (this.cancelScpt) this.cancelScpt.unsubscribe();
+  }
+
+  show() {
+    this.spinner.show();
+  }
+
+  hide() {
+    this.spinner.hide();
+  }
+
+}

--- a/src/app/shared/models/spinner/spinner.module.spec.ts
+++ b/src/app/shared/models/spinner/spinner.module.spec.ts
@@ -1,0 +1,13 @@
+import { SpinnerModule } from './spinner.module';
+
+describe('SpinnerModule', () => {
+  let spinnerModule: SpinnerModule;
+
+  beforeEach(() => {
+    spinnerModule = new SpinnerModule();
+  });
+
+  it('should create an instance', () => {
+    expect(spinnerModule).toBeTruthy();
+  });
+});

--- a/src/app/shared/models/spinner/spinner.module.ts
+++ b/src/app/shared/models/spinner/spinner.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SpinnerComponent } from './spinner.component';
+import { NgxSpinnerModule } from 'ngx-spinner';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    NgxSpinnerModule
+  ],
+  exports: [
+    SpinnerComponent
+  ],
+  declarations: [ SpinnerComponent ],
+  entryComponents: [ SpinnerComponent ]
+})
+export class SpinnerModule { }


### PR DESCRIPTION
1. 完成 - "Basic" ( 1個參數表格 )、"Advanced  ( 28 個參數表格 )" 兩種模式各參數欄位正確填值、衝突欄位判定機制、與隨是否衝突顯示覆蓋模式種類(Action欄位)機制 。
2. 完成 - 可使用上方 Filter 切換基站不同 Cell 對應參數值之機制。

### 此"基本參數"欄位還缺 DB → gNB、DB ← gNB 覆蓋數據功能。

Others:
1. 新增外包建議 Spinner 模組。 (還未能使用)