### PR TITLE
基站建立 - 修正組成 components 數據的方式

### DIFF
--- a/src/app/bs-management/bs-management.component.ts
+++ b/src/app/bs-management/bs-management.component.ts
@@ -643,16 +643,13 @@ export class BSManagementComponent implements OnInit {
   
           // Define components with the appropriate type
           const components: Components_Dist = {};
-  
           components[cu] = duElements.reduce((acc: duID, du: any) => {
-              const filteredRUs = ruElements.filter((ru: any) => ru.duid === du.id);
-              const ruMap: ruID = filteredRUs.reduce((ruAcc: ruID, ru: any) => {
-                  ruAcc[ru.id] = ru.position;
-                  return ruAcc;
-              }, {});
-              
-              acc[du.id] = [ruMap];  // Adjust this if the structure needs to be different
-              return acc;
+            const filteredRUs = ruElements.filter((ru: any) => ru.duid === du.id);
+            const ruMap: ruID[] = filteredRUs.map((ru: any) => ({
+              [ru.id]: ru.position
+            }));
+            acc[du.id] = ruMap;
+            return acc;
           }, {});
   
           this.bsCreationData.components = components;


### PR DESCRIPTION
feat: 調整 components 資料結構

- 修改 components 的型別定義，使其符合介面定義
- 調整 components 的組成邏輯，確保每個 du 下的 ru 都是獨立的物件
- 現在每個 du 下的 ru 都是一個 ruID[] 陣列，其中每個元素都是一個單獨的 ruID 物件
- 修復了型別不匹配的問題，程式碼現在可以通過型別檢查

feat: Adjust the structure of components

- Modify the type definition of components to match the interface definition
- Adjust the composition logic of components to ensure that each ru under a du is an independent object
- Now, each ru under a du is an ruID[] array, where each element is a separate ruID object
- Fix the type mismatch issue, and the code can now pass type checking