### PR TITLE
實現系統內一致的「Back 鍵」按鈕行為並優化場域資訊頁的處理

### DIFF
--- a/src/app/account-management/account-info/account-info.component.html
+++ b/src/app/account-management/account-info/account-info.component.html
@@ -1,7 +1,7 @@
 <div class="ocloudInfo account_Info">
   <h5>
     <button (click)="back()">
-      <span class="material-icons">arrow_back</span>Back
+      <span class="material-icons">arrow_back</span>{{ languageService.i18n['back'] }}
     </button>
     Account {{languageService.i18n['information']}} – {{accountInfo.id}}
   </h5>

--- a/src/app/account-management/account-info/account-info.component.ts
+++ b/src/app/account-management/account-info/account-info.component.ts
@@ -10,6 +10,9 @@ import { MatButtonToggleChange } from '@angular/material/button-toggle';
 import { SystemSummary } from 'src/app/dashboard/dashboard.component';
 import { LanguageService } from 'src/app/shared/service/language.service';
 
+// @2024/05/03 Add
+import { Location } from '@angular/common';  // 引入 Location 服務，用於控制瀏覽器的歷史記錄導航
+
 export interface AccountInfo {
   id: string;
   key: string;
@@ -75,6 +78,7 @@ export class AccountInfoComponent implements OnInit {
     public commonService: CommonService,
     private fb: FormBuilder,
     private dialog: MatDialog,
+    private       location: Location,      // @2024/05/03 Add
     public languageService: LanguageService
   ) {
     this.severitys = this.commonService.severitys;
@@ -94,6 +98,13 @@ export class AccountInfoComponent implements OnInit {
       console.log('cloudId=' + this.cloudId + ', cloudName=' + this.cloudName);
       this.getAccountInfo();
     });
+  }
+
+  // @2024/05/03 Update
+  // 返回使用的上個頁面
+  back() {
+    this.location.back();
+    // this.router.navigate(['/main/account-mgr']); // 返回 account 主頁
   }
 
   roleDisplayName(role: string): string {
@@ -171,9 +182,6 @@ export class AccountInfoComponent implements OnInit {
   nfRefresh() {
     // refresh
     this.accInfoRefreshTimeout = window.setTimeout(() => this.getAccountInfo(), this.accInfoRefreshTime * 1000);
-  }
-  back() {
-    this.router.navigate(['/main/account-mgr']);
   }
 
   openUpdateModel() {

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -13,15 +13,15 @@ import { DashboardComponent } from './dashboard/dashboard.component';   // 主�
 
 // 場域管理
 import { FieldManagementComponent } from './field-management/field-management.component'; 
-import { FieldInfoComponent } from './field-management/field-info/field-info.component';
+import { FieldInfoComponent }       from './field-management/field-info/field-info.component';
 
 // 基站管理 頁     @12/27 Add by yuchen 
 import { BSManagementComponent } from './bs-management/bs-management.component';                        
-import { BSInfoComponent } from './bs-management/bs-info/bs-info.component'; // 基站管理資訊  @12/27 Add by yuchen 
+import { BSInfoComponent }       from './bs-management/bs-info/bs-info.component'; // 基站管理資訊  @12/27 Add by yuchen 
 
 // 元件管理頁
 import { ComponentManagementComponent } from './component-management/component-management.component';
-import { ComponentInfoComponent } from './component-management/component-info/component-info.component';
+import { ComponentInfoComponent }       from './component-management/component-info/component-info.component';
 
 // 故障管理頁
 import { FaultManagementComponent } from './fault-management/fault-management.component';  
@@ -29,30 +29,30 @@ import { FaultManagementComponent } from './fault-management/fault-management.co
 // 效能管理 頁
 import { PerformanceManagementComponent } from './performance-management/performance-management.component';  
 import { OCloudPerformanceInfoComponent } from './performance-management/o-cloud-performance-info/o-cloud-performance-info.component';
-import { NfPerformanceInfoComponent } from './performance-management/nf-performance-info/nf-performance-info.component';
+import { NfPerformanceInfoComponent }     from './performance-management/nf-performance-info/nf-performance-info.component';
 
 // 切片管理 頁 @2024/05/03 Add by Yuchen
 import { SliceManagementComponent } from './slice-management/slice-management.component';     
-import { SliceInfoComponent } from './slice-management/slice-info/slice-info.component'; // 切片管理資訊頁
+import { SliceInfoComponent }       from './slice-management/slice-info/slice-info.component'; // 切片管理資訊頁
 
 // 軟體管理 頁
 import { SoftwareManagementComponent } from './software-management/software-management.component';     
-import { SoftwareInfoComponent } from './software-management/software-info/software-info.component';
+import { SoftwareInfoComponent }       from './software-management/software-info/software-info.component';
 
 // 排程管理 頁 @11/20 Add by yuchen
 import { ScheduleManagementComponent } from './schedule-management/schedule-management.component';     
-import { ScheduleInfoComponent } from './schedule-management/schedule-info/schedule-info.component'; // 排程管理資訊  @11/20 Add by yuchen 
+import { ScheduleInfoComponent }       from './schedule-management/schedule-info/schedule-info.component'; // 排程管理資訊  @11/20 Add by yuchen 
 
 // 日誌管理 頁  @10/25 Add by yuchen 
-import { LogManagementComponent } from './log-management/log-management.component';   
+import { LogManagementComponent }     from './log-management/log-management.component';   
 
 // 帳號管理 頁
 import { AccountManagementComponent } from './account-management/account-management.component';      
-import { AccountInfoComponent } from './account-management/account-info/account-info.component';
+import { AccountInfoComponent }       from './account-management/account-info/account-info.component';
 
 // O2 的 ( 最後刪掉 )
-import { NfManagementComponent } from './nf-management/nf-management.component';      // NF管理
-import { NfInfoComponent } from './nf-management/nf-info/nf-info.component';
+import { NfManagementComponent } from './nf-management/nf-management.component';   // NF 管理
+import { NfInfoComponent }       from './nf-management/nf-info/nf-info.component';
 
 const routes: Routes = [
   { path: '', redirectTo: 'login', pathMatch: 'full' },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -101,17 +101,22 @@ import { MatDividerModule } from '@angular/material/divider';
 import { MatListModule } from '@angular/material/list';
 import { ToggleButtonModule } from 'primeng/togglebutton';
 
-import { FormBuilder, FormGroup } from '@angular/forms';       // @2024/01/31 Add
-import { MatInputModule } from '@angular/material/input';      // @2024/01/31 Add
-import { MatStepperModule } from '@angular/material/stepper';  // @2024/01/31 Add
+import { MatInputModule }     from '@angular/material/input';     // @2024/01/31 Add
+import { MatStepperModule }   from '@angular/material/stepper';   // @2024/01/31 Add
 import { MatExpansionModule } from '@angular/material/expansion'; // 用於縮合效果 @2024/02/29 Add
-import { MatCheckboxModule } from '@angular/material/checkbox'; // @2024/03/30 Add
+import { MatCheckboxModule }  from '@angular/material/checkbox';  // @2024/03/30 Add
+
+// @2024/05/03 Add
+import { Location } from '@angular/common';  // 引入 Location 服務，用於控制瀏覽器的歷史記錄導航
 
 // Services
 import { CommonService } from './shared/common.service';
 import { LanguageService } from './shared/service/language.service';
-import { SpinnerService } from './shared/service/spinner.service'; // 用於控制顯示 Spinner @2024/04/17 Add
+import { SpinnerService } from './shared/service/spinner.service';        // 用於控制顯示 Spinner @2024/04/17 Add
+import { FieldStateService } from './shared/service/field-state.service'; // 用於跟蹤場域頁面的 showMapModel 的顯示模式狀態 @2024/05/03 Add
+import { NavigationService } from './shared/service/navigation.service';  // 用於跟蹤路由歷史 @2024/05/03 Add
 import { NgxSpinnerModule } from "ngx-spinner";
+
 
 // Pipe 管道
 import { TruncatePipe } from './shared/pipes/truncate.pipe';             // @11/16 Add by yuchen 
@@ -249,7 +254,7 @@ import { localUnusedNEList }    from './shared/local-files/NE/For_queryUnusedNeL
     MatCheckboxModule,  // @2024/03/30 Add
 
     BrowserAnimationsModule,
-    SpinnerModule,// @2024/04/17 Add
+    SpinnerModule,      // @2024/04/17 Add
     NgxSpinnerModule
   ],
   providers: [
@@ -257,6 +262,9 @@ import { localUnusedNEList }    from './shared/local-files/NE/For_queryUnusedNeL
     LanguageService,
     CommonService,
     SpinnerService,     // @2024/04/17 Add for Control Spinner
+    Location,           // 在 providers 中提供 Location 服務，用於控制瀏覽器的歷史記錄導航 @2024/05/03 Add
+    FieldStateService,  // 用於跟蹤場域頁面的 showMapModel 的顯示模式狀態 @2024/05/03 Add
+    NavigationService,  // 用於跟蹤路由歷史 @2024/05/03 Add
 
     apiForFieldMgmt,    // @2024/03/14 Update for import API of Field Management
     apiForBSMgmt,       // @2024/03/14 Add for import API of BS Management

--- a/src/app/bs-management/bs-info/bs-info.component.html
+++ b/src/app/bs-management/bs-info/bs-info.component.html
@@ -1,6 +1,6 @@
 <div class="ocloudInfo component bs-info">
   <h5>
-    <button (click)="back()"><span class="material-icons">arrow_back</span>Back</button>
+    <button (click)="back()"><span class="material-icons">arrow_back</span>{{ languageService.i18n['back'] }}</button>
       {{ languageService.i18n['BS.info'] }} – {{ bsName }} /
     <label *ngIf=" bsType === '1' ">All-in-one:&thinsp;[CU + DU + RU]</label>
     <label *ngIf=" bsType === '2' ">Disaggregated:&thinsp;[CU] + [DU] + [RU]</label>

--- a/src/app/bs-management/bs-info/bs-info.component.ts
+++ b/src/app/bs-management/bs-info/bs-info.component.ts
@@ -36,6 +36,8 @@ import { localBSInfo } from '../../shared/local-files/BS/For_queryBsInfo';      
 import { localNEList } from '../../shared/local-files/NE/For_queryBsComponentList'; // @2024/03/27 Add
 import { localCurrentBsFmList } from '../../shared/local-files/BS/For_queryCurrentBsFaultMessage'; // @2024/03/31 Add
 
+// @2024/05/03 Add
+import { Location } from '@angular/common';  // 引入 Location 服務，用於控制瀏覽器的歷史記錄導航
 
 // 2024/04/01 Add
 // 搜尋基站告警用
@@ -66,10 +68,12 @@ export class BSInfoComponent implements OnInit {
     private          route: ActivatedRoute,
     private             fb: FormBuilder,
     private         dialog: MatDialog,
-    public   commonService: CommonService,
-    public languageService: LanguageService,
-    public  spinnerService: SpinnerService,
+    private          location: Location,      // @2024/05/03 Add
+    public      commonService: CommonService,
+    public    languageService: LanguageService,
+    public     spinnerService: SpinnerService,
     private changeDetectorRef: ChangeDetectorRef,
+    
 
     public  API_BS: apiForBSMgmt,           // @2024/03/25 Add for import API of BS Management
     public  bsInfo_LocalFiles: localBSInfo, // @2024/03/25 Add for import BS Info Local Files 
@@ -173,13 +177,13 @@ export class BSInfoComponent implements OnInit {
     //});
     //this.changeDetectorRef.detectChanges(); // 手動觸發變更檢測
 
-   // this.hideSpinner();  // 完成後隱藏 spinner
-
   }
 
-  // 用於返回 BS 主頁 @2024/03/25 Add
+  // @2024/05/03 Update
+  // 返回使用的前個頁面
   back() {
-    this.router.navigate( ['/main/bs-mgr'] );
+    this.location.back();
+    //this.router.navigate( ['/main/bs-mgr'] ); // 返回 BS 主頁
   }
 
   // @2024/04/17 Add

--- a/src/app/component-management/component-info/component-info.component.html
+++ b/src/app/component-management/component-info/component-info.component.html
@@ -1,6 +1,6 @@
 <div class="ocloudInfo component">
   <h5>
-    <button (click)="back()"><span class="material-icons">arrow_back</span>Back</button>
+    <button (click)="back()"><span class="material-icons">arrow_back</span>{{ languageService.i18n['back'] }}</button>
     {{languageService.i18n['cm.info']}} – {{componentInfo.name}}
   </h5>
 

--- a/src/app/component-management/component-info/component-info.component.ts
+++ b/src/app/component-management/component-info/component-info.component.ts
@@ -15,6 +15,9 @@ import { Subscription } from 'rxjs';
 import { XMLParser } from "fast-xml-parser";
 import * as xmlJs from 'xml-js';
 
+// @2024/05/03 Add
+import { Location } from '@angular/common';  // 引入 Location 服務，用於控制瀏覽器的歷史記錄導航
+
 //component Info
 export interface ComponentInfo {
   id: string;
@@ -184,6 +187,7 @@ export class ComponentInfoComponent implements OnInit {
     public commonService: CommonService,
     private fb: FormBuilder,
     private dialog: MatDialog,
+    private       location: Location,      // @2024/05/03 Add
     public languageService: LanguageService
   ) {
     this.severitys = this.commonService.severitys;
@@ -628,8 +632,11 @@ export class ComponentInfoComponent implements OnInit {
     return this.commonService.severityText(severity);
   }
 
+  // @2024/05/03 Update
+  // 返回使用的前個頁面
   back() {
-    this.router.navigate(['/main/component-mgr']);
+    this.location.back();
+    //this.router.navigate( ['/main/component-mgr'] ); // 返回 NE 主頁
   }
 
   goFaultMgr() {

--- a/src/app/field-management/field-info/field-info.component.html
+++ b/src/app/field-management/field-info/field-info.component.html
@@ -2,7 +2,7 @@
 <div class="ocloudInfo">
 	<h5>
 		<button (click)="back()">
-		  <span class="material-icons back">arrow_back</span>Back
+		  <span class="material-icons back">arrow_back</span>{{ languageService.i18n['back'] }}
 		</button>
 
 		<!-- <span>{{languageService.i18n['field.info']}} – {{fieldName}}</span> -->

--- a/src/app/schedule-management/schedule-info/schedule-info.component.html
+++ b/src/app/schedule-management/schedule-info/schedule-info.component.html
@@ -2,7 +2,7 @@
 <div class="ocloudInfo schedule" [ngClass]="getDynamicClasses( selectScheduleInfo )">
   <h5>
     <button (click)="back()">
-      <span class="material-icons">arrow_back</span>Back
+      <span class="material-icons">arrow_back</span>{{ languageService.i18n['back'] }}
     </button>
     {{languageService.i18n['sm.info']}} – 
     <label *ngIf=" selectScheduleInfo.tickettype === '0' ">{{ languageService.i18n['sm.sfUpdate'] }}</label>

--- a/src/app/schedule-management/schedule-info/schedule-info.component.ts
+++ b/src/app/schedule-management/schedule-info/schedule-info.component.ts
@@ -12,6 +12,9 @@ import { FaultMessages } from './../../fault-management/fault-management.compone
 import { Subscription }  from 'rxjs';
 import { XMLParser }     from "fast-xml-parser";
 
+// @2024/05/03 Add
+import { Location } from '@angular/common';  // 引入 Location 服務，用於控制瀏覽器的歷史記錄導航
+
 // Services
 import { CommonService } from '../../shared/common.service';
 import { LanguageService } from '../../shared/service/language.service';
@@ -40,9 +43,11 @@ export class ScheduleInfoComponent implements OnInit {
   refreshTimeout!: any;     // refreshTimeout 用於存儲 setTimeout 的引用，方便之後清除
   refreshTime: number = 5;  // refreshTime 定義自動刷新的時間間隔（秒）
 
-  // 返回 Schedule Management 主頁
+  // @2024/05/03 Update
+  // 返回使用的前個頁面
   back() {
-    this.router.navigate(['/main/schedule-mgr']);
+    this.location.back();
+    //this.router.navigate( ['/main/schedule-mgr'] ); // 返回 schedule 主頁
   }
 
   // @2024/04/17 Add
@@ -70,6 +75,7 @@ export class ScheduleInfoComponent implements OnInit {
     private         router: Router,
     private          route: ActivatedRoute,
     private         dialog: MatDialog,
+    private       location: Location,  // @2024/05/03 Add
     public   commonService: CommonService,
     public languageService: LanguageService,
     public  spinnerService: SpinnerService,

--- a/src/app/shared/language-models/en-language.ts
+++ b/src/app/shared/language-models/en-language.ts
@@ -46,6 +46,7 @@ export const Enlanguage = {
   'table.delete':'Delete',
   
   // Common Items
+  "back": 'Back',
   'ok':'OK',
   'confirm':'Confirm',  // @2024/01/10 Add by yuchen
   'cancel':'Cancel',

--- a/src/app/shared/language-models/tw-language.ts
+++ b/src/app/shared/language-models/tw-language.ts
@@ -45,14 +45,15 @@ export const TwLanguage = {
   'table.delete':'刪除',
   
   // Common Items (共用項目)
+  "back": '返回',
   'ok':'確定',
   'confirm':'確認',             // @2024/01/10 Add by yuchen
   'cancel':'取消',
   'search':'搜尋',
   'search_criteria':'篩選條件',  // @12/04 Add by yuchen
   'clear_search':'重置搜尋',     // @11/24 Add by yuchen
-  'close': '關閉',              // @2024/01/22 Add
-  'clear_select':'重置選擇',   // @2024/04/25 Add
+  'close': '關閉',               // @2024/01/22 Add
+  'clear_select':'重置選擇',     // @2024/04/25 Add
 
   // Field Management (場域管理) @11/30 Add by yuchen
   'field.list':'場域列表',
@@ -207,8 +208,6 @@ export const TwLanguage = {
   'field.legend_all-in-one_bs':'一體式基站',  // @12/28 Add
   'field.legend_dist_bs':'分佈式基站',       // @12/28 Add
   
-
-
   'field.selectOptimizationParameters': '選擇優化參數',
   'field.selectCalculationParameters': '選擇計算參數',
 

--- a/src/app/shared/service/field-state.service.ts
+++ b/src/app/shared/service/field-state.service.ts
@@ -1,0 +1,41 @@
+/* 
+    @2024/05/03 Add
+    主要功能是追蹤場域頁面的 showMapModel 顯示模式狀態。
+    此服務檔案的功用是提供一個簡單的方式來追蹤應用中場域訊息頁面的顯示狀態變化。
+    它存儲了用戶在場域資訊頁面選擇的地圖模式或基站列表模式的狀態，使得應用可以在任何時刻訪問和修改用戶的顯示偏好。
+    這對於創建基於用戶界面顯示狀態的特定邏輯或用戶體驗改進（例如，在不同模式間切換或維持狀態）非常有用。
+*/
+
+// 引入 Angular 的核心模塊中的 Injectable 裝飾器。
+import { Injectable } from '@angular/core';
+
+// 定義一個可注入的服務，提供於根模塊，使其在整個應用中可用。
+@Injectable({
+  providedIn: 'root'
+})
+export class FieldStateService {  // 定義一個服務類 FieldStateService
+  
+  private _showMapModel: boolean = true;  // 私有屬性 _showMapModel，初始化為 true，用來存儲場域地圖模式的顯示狀態
+  
+  private _directReturnFromBSInfo: boolean = false;  // 新增私有屬性，用於追蹤是否直接從基站詳細訊息頁返回
+
+  // 公共的 getter 方法，用於外部獲取 _showMapModel 的值
+  get showMapModel(): boolean {
+    return this._showMapModel;
+  }
+
+  // 公共的 setter 方法，用於外部設置 _showMapModel 的值
+  set showMapModel( value: boolean ) {
+    this._showMapModel = value;  // 更新 _showMapModel 的值
+  }
+
+  // 公共的 getter 方法，用於外部獲取 _directReturnFromBSInfo 的值
+  get directReturnFromBSInfo(): boolean {
+    return this._directReturnFromBSInfo;
+  }
+
+  // 公共的 setter 方法，用於外部設置 _directReturnFromBSInfo 的值
+  set directReturnFromBSInfo( value: boolean ) {
+    this._directReturnFromBSInfo = value;
+  }
+}

--- a/src/app/shared/service/navigation.service.ts
+++ b/src/app/shared/service/navigation.service.ts
@@ -1,0 +1,37 @@
+/* 
+    @2024/05/03 Add
+    主要功能是追蹤用戶的導航歷史。
+    此服務檔案的功用是提供一個簡單的方式來追蹤應用中的路由變化。
+    它存儲了用戶的導航歷史，使得應用可以在任何時刻訪問用戶之前訪問過的路由。
+    這對於創建基於導航歷史的特定邏輯或用戶體驗改進（例如「返回」按鈕的行為）非常有用。
+
+*/
+
+// 引入 Angular 的核心模組和相關函數。
+import { Injectable } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
+import { filter } from 'rxjs/operators';
+
+// 定義一個可注入的服務，提供於根模組，使其在整個應用中可用。
+@Injectable({
+  providedIn: 'root'
+})
+export class NavigationService {  // 定義 NavigationService 類
+  history: string[] = [];         // 定義一個數組來存儲導航的 URL 歷史
+
+  // 類的構造函數，注入 Router 來訪問導航事件
+  constructor( private router: Router ) {
+    this.router.events  // 監聽路由事件
+      .pipe(
+        filter( ( event ): event is NavigationEnd => event instanceof NavigationEnd ) // 使用 filter 篩選只有 NavigationEnd 類型的事件
+      )
+      .subscribe( ( event: NavigationEnd ) => {       // 訂閱事件流
+        this.history.push( event.urlAfterRedirects ); // 將導航結束後的 URL 添加到歷史數組中
+      });
+  }
+
+  // 提供一個方法來獲取倒數第二個訪問的 URL，如果歷史數據少於兩個，則返回根路徑 '/'
+  getPreviousUrl(): string {
+    return this.history[this.history.length - 2] || '/';
+  }
+}

--- a/src/app/slice-management/slice-info/slice-info.component.html
+++ b/src/app/slice-management/slice-info/slice-info.component.html
@@ -2,7 +2,7 @@
 <div class="ocloudInfo schedule" [ngClass]="getDynamicClasses( selectScheduleInfo )">
   <h5>
     <button (click)="back()">
-      <span class="material-icons">arrow_back</span>Back
+      <span class="material-icons">arrow_back</span>{{ languageService.i18n['back'] }}
     </button>
     {{languageService.i18n['slice.info']}} – 
     <label *ngIf=" selectScheduleInfo.tickettype === '0' ">{{ languageService.i18n['sm.sfUpdate'] }}</label>

--- a/src/app/slice-management/slice-info/slice-info.component.ts
+++ b/src/app/slice-management/slice-info/slice-info.component.ts
@@ -12,6 +12,9 @@ import { FaultMessages } from './../../fault-management/fault-management.compone
 import { Subscription }  from 'rxjs';
 import { XMLParser }     from "fast-xml-parser";
 
+// @2024/05/03 Add
+import { Location } from '@angular/common';  // 引入 Location 服務，用於控制瀏覽器的歷史記錄導航
+
 // Services
 import { CommonService } from '../../shared/common.service';
 import { LanguageService } from '../../shared/service/language.service';
@@ -40,9 +43,11 @@ export class SliceInfoComponent implements OnInit {
   refreshTimeout!: any;     // refreshTimeout 用於存儲 setTimeout 的引用，方便之後清除
   refreshTime: number = 5;  // refreshTime 定義自動刷新的時間間隔（秒）
 
-  // 返回 Slice Management 主頁
+  // @2024/05/03 Update
+  // 返回使用的前個頁面
   back() {
-    this.router.navigate(['/main/slice-mgr']);
+    this.location.back();
+    //this.router.navigate( ['/main/slice-mgr'] ); // 返回 Slice 主頁
   }
 
   // @2024/04/17 Add
@@ -70,6 +75,7 @@ export class SliceInfoComponent implements OnInit {
     private         router: Router,
     private          route: ActivatedRoute,
     private         dialog: MatDialog,
+    private       location: Location,        // @2024/05/03 Add
     public   commonService: CommonService,
     public languageService: LanguageService,
     public  spinnerService: SpinnerService,

--- a/src/app/software-management/software-info/software-info.component.html
+++ b/src/app/software-management/software-info/software-info.component.html
@@ -1,7 +1,7 @@
 <div class="ocloudInfo software">
   <h5>
     <button (click)="back()">
-      <span class="material-icons">arrow_back</span>Back
+      <span class="material-icons">arrow_back</span>{{ languageService.i18n['back'] }}
     </button>
     Software {{languageService.i18n['information']}} – {{softwareInfo.firm}}/{{softwareInfo.modelname}} {{mapUploadType(softwareInfo.uploadtype)}} {{softwareInfo.uploadversion}}
   </h5>

--- a/src/app/software-management/software-info/software-info.component.ts
+++ b/src/app/software-management/software-info/software-info.component.ts
@@ -11,6 +11,9 @@ import { SystemSummary } from 'src/app/dashboard/dashboard.component';
 import { LanguageService } from 'src/app/shared/service/language.service';
 import { Item } from 'src/app/shared/models/item';
 
+// @2024/05/03 Add
+import { Location } from '@angular/common';  // 引入 Location 服務，用於控制瀏覽器的歷史記錄導航
+
 export interface SoftwareInfo {
   id: string;
   firm: string;
@@ -84,7 +87,9 @@ export class SoftwareInfoComponent implements OnInit {
     private http: HttpClient,
     private fb: FormBuilder,
     private dialog: MatDialog,
-    public languageService: LanguageService
+    public languageService: LanguageService,
+    private location: Location,  // @2024/05/03 Add
+
   ) {
     this.uploadtypeUI.forEach((row) => this.typeMap.set(Number(row.value), row.displayName));
   }
@@ -181,20 +186,27 @@ export class SoftwareInfoComponent implements OnInit {
     }
   }
 
+  // @2024/05/03 Update
+  // 返回使用的前個頁面
   back() {
-    this.router.navigate(['/main/software-mgr']);
+    this.location.back();
+    //this.router.navigate( ['/main/software-mgr'] ); // 返回 software 主頁
   }
 
   update() {
-    if (this.commonService.isLocal) {
+    if ( this.commonService.isLocal ) {
       /* local file test */
+
       this.updateModalRef.close();
+
     } else {
       let fileName: string | null = null;
-      if (this.file) {
+
+      if ( this.file ) {
         const file: FileObject = this.file;
         fileName = file.name;
       }
+
       const uploadinfo = this.file ? fileName : this.softwareInfo.uploadinfo; 
       const body: any = {
         id: this.softwareInfo.id,
@@ -209,16 +221,20 @@ export class SoftwareInfoComponent implements OnInit {
         uploadversion: this.softwareInfo.uploadversion,
         session: this.sessionId
       };
-      console.log(body);
-      this.commonService.updateUploadFileInfo(body).subscribe(
+
+      console.log( body );
+      this.commonService.updateUploadFileInfo( body ).subscribe(
         () => console.log('Update Successful.')
       );
-      if (this.file){
+
+      if ( this.file ){
+
         const uploadFirmware = `${this.commonService.restPath}/uploadFirmware/${this.sessionId}/${this.softwareInfo.id}`;
         const formData = new FormData();
         formData.append('file', this.file);
         const headers = new HttpHeaders();
-        this.http.post(uploadFirmware, formData, {headers}).subscribe(
+
+        this.http.post( uploadFirmware, formData, {headers} ).subscribe(
           () => {
             this.updateModalRef.close();
             this.getSoftwareInfo();
@@ -230,19 +246,27 @@ export class SoftwareInfoComponent implements OnInit {
     }
     this.getSoftwareInfo();
   }
+
   refresh() {
-    this.softwareInfoRefreshTimeout = window.setTimeout(() => this.getSoftwareInfo(), this.softwareInfoRefreshTime * 1000);
+    this.softwareInfoRefreshTimeout = window.setTimeout( () => this.getSoftwareInfo(), this.softwareInfoRefreshTime * 1000 );
   }
+
   openUpdateModel() {
+
     this.formValidated = false;
+
     //this.softwareInfo = softwareInfo;
+
     this.updateForm = this.fb.group({
       'type': new FormControl('imageUrl'),
       'imageUrl': new FormControl('', [Validators.required]),
       'fileName': new FormControl('')
     });
+
     this.softwarecontent;
-    this.updateModalRef = this.dialog.open(this.updateModal, { id: 'softUpdateModal' });
+
+    this.updateModalRef = this.dialog.open( this.updateModal, { id: 'softUpdateModal' } );
+
     this.updateModalRef.afterClosed().subscribe(() => {
       this.formValidated = false;
     });


### PR DESCRIPTION
實現系統內一致的返回按鈕行為並優化場域資訊頁的處理

此提交確保按下應用程序中的任何「Back」按鈕時，
都能將用戶返回到先前使用的頁面，維持一致的用戶導航體驗。
此外，引入了針對場域資訊頁在地圖模式和基站列表模式間切換時的特定邏輯。
現在，系統會記住最後的狀態（地圖或列表），並在返回場域資訊頁時恢復該狀態，改善了不同導航場景下的用戶互動。修改了導航邏輯，以有效跟蹤和利用瀏覽器的歷史堆疊。

Implement consistent back button behavior and enhance field info page handling

This commit ensures that pressing any 'Back' button in the application returns the user to the previously used page, thereby maintaining a consistent user navigation experience. It also introduces specific logic for the field info page when switching between map and BS list modes. Now, the system remembers the last state (map or list) and restores it when navigating back to the field info page, improving the user interaction in varying navigation scenarios. Modified navigation logic to track and utilize the browser's history stack effectively.

## Back 鍵之顯示文字，改為能切換中英兩版