### PR TITLE
調整 filterData() 裡 default 選項顯示一體式基站 Cell 數據時的條件判斷

### DIFF
--- a/src/app/bs-management/bs-info/bs-info.component.ts
+++ b/src/app/bs-management/bs-info/bs-info.component.ts
@@ -4057,7 +4057,7 @@ export class BSInfoComponent implements OnInit {
                             const defaultNci = this.nciList[0];
     
                             // 使用 nci 值在 label 中標示 Cell#
-                            if ( `0x${defaultNci}` === cellId ) { // <-- @2024/05/19 修改的部分 - 確保只有在 nci 匹配時才添加數據
+                            if ( defaultNci === cellId ) { // <-- @2024/05/19 修改的部分 - 確保只有在 nci 匹配時才添加數據
                                 filteredData.push( { name: `Cell#1 ( NCI=0x${defaultNci} ) `, series: series } );
                             }
                         } else {


### PR DESCRIPTION
 if ( `0x${defaultNci}` === cellId ) 調整成 if ( defaultNci === cellId )，
因 cellId 已經於前面處理成未有前面 0x 的格式，故作此調整，
否則選擇一體式基站的 Cell 選項時會無法取得數據。