### PR TITLE
基站效能區 - 修正圖表在檢視單一數據時不會依據完整資訊的配色顯示顏色的問題

### DIFF
--- a/src/app/bs-management/bs-info/bs-info.component.html
+++ b/src/app/bs-management/bs-info/bs-info.component.html
@@ -5122,22 +5122,25 @@
               </span>
             </div>
               
+            <!-- ngx-charts-line-chart 圖表模組區 -->
             <ngx-charts-line-chart
               [view]="view"
               [scheme]="colorScheme"
+              [customColors]="customColors"
               [legend]="legend"
-              [legendTitle]="this.languageService.i18n['BS.dataSource']"
+              [legendTitle]="legendTitle"
               [showXAxisLabel]="showXAxisLabel"
               [showYAxisLabel]="showYAxisLabel"
               [xAxis]="xAxis"
               [yAxis]="yAxis"
-              [xAxisLabel]="this.languageService.i18n['BS.timeIntervalHourly']"
+              [xAxisLabel]="xAxisLabel"
               [yAxisLabel]="yAxisLabel"
-              [roundDomains]="true"
-              [autoScale]="true"
+              [roundDomains]="roundDomains"
+              [autoScale]="autoScale"
               [showGridLines]="showGridLines"
               [results]="filteredData">
-              <!-- 自定義工具提示(顯示單數據條的提示) 模板 @2024/05/20 Update  -->
+
+              <!-- 自定義工具提示(顯示單數據條的提示) 模板 @2024/05/20 Update -->
               <ng-template #tooltipTemplate let-model="model">
                 <div>
                   <!-- 用於查看生成的 JSON 數據 -->
@@ -5149,8 +5152,8 @@
                   <span>{{ model.time }} : {{ model.value }} {{ model.unit }}</span>
                 </div>
               </ng-template>
-              
-               <!-- 自定義工具提示 ( 顯示所有數據條的提示 ) 模板 @2024/05/20 Add -->
+            
+              <!-- 自定義工具提示 ( 顯示所有數據條的提示 ) 模板 @2024/05/20 Add -->
               <ng-template #seriesTooltipTemplate let-model="model">
                 <div>
                   <!-- 用於查看生成的 JSON 數據 -->
@@ -5161,10 +5164,10 @@
                   <!-- 顏色塊 -->
                   <span [style.background-color]="mod.color" style="width: 12px; height: 12px; display: inline-block; margin-right: 4px;"></span>
                   <!-- 數據內容 -->
-                  <!-- <span>{{mod.name}} - {{ mod.series }} : {{ mod.value }} {{ mod.unit }}</span> -->
                   <span>{{ mod.series }} : {{ mod.value }} {{ mod.unit }}</span>
                 </div>
-              </ng-template>              
+              </ng-template>
+              
             </ngx-charts-line-chart>
 
         </div>


### PR DESCRIPTION
解決 '單一數據檢視不會依據檢視完整資訊的配色顯示，只會預設顯示第一種配色#FF5733' 的狀況。引入 ngx-charts 的 [customColors] 參數設定，並處理儲存完整資訊的配色，才解決此問題。