### PR TITLE
基站效能區 - 新增圖表底下資料項目表格

### DIFF
--- a/src/app/bs-management/bs-info/bs-info.component.html
+++ b/src/app/bs-management/bs-info/bs-info.component.html
@@ -5123,13 +5123,13 @@
             </div>
 
             <div>
-              <!-- ngx-charts-line-chart 圖表模組區 @2024/05/24 Update -->
+              <!-- ngx-charts-line-chart 圖表模組區 @2024/05/27 Update -->
               <ngx-charts-line-chart
                 [view]="view"
                 [scheme]="colorScheme"
                 [customColors]="customColors"
                 [legend]="legend"
-                [legendTitle]="this.languageService.i18n['BS.dataSource']"
+                [legendTitle]="this.languageService.i18n['BS.dataItems']"
                 [showXAxisLabel]="showXAxisLabel"
                 [showYAxisLabel]="showYAxisLabel"
                 [xAxis]="xAxis"
@@ -5174,8 +5174,30 @@
                 </ng-template>
               
               </ngx-charts-line-chart>
+              <!-- 表格區 @2024/05/27 Add -->
+              <div class="table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>
+                        <span>{{ languageService.i18n['BS.dataItems'] }}</span>\
+                        <span>{{ languageService.i18n['BS.hourlyInterval'] }}</span>
+                      </th>
+                      <th *ngFor="let timeBlock of displayOnTableChartData[0]?.series">{{ timeBlock.time }}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr *ngFor="let series of displayOnTableChartData">
+                      <td>{{ series.name }}</td>
+                      <td *ngFor="let dataPoint of series.series">
+                        <span *ngIf="dataPoint.value !== null">{{ dataPoint.value }}&thinsp;{{ dataPoint.unit }}</span>
+                        <span *ngIf="dataPoint.value === null">{{ languageService.i18n['BS.kpiValueNone'] }}</span>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>              
             </div>
-
         </div>
       </div>
     </div>

--- a/src/app/shared/language-models/en-language.ts
+++ b/src/app/shared/language-models/en-language.ts
@@ -203,6 +203,7 @@ export const Enlanguage = {
   'field.performanceHistory':'History',   // @2024/05/27 Add
   'field.historyPerformanceSearch': 'Historical Performance Search', // @2024/05/27 Add
   'field.performanceHistorySearch': 'Performance History Search',    // @2024/05/27 Add
+  'field.items':'Items',  // @2024/05/27 Add
 
   'field.reportFM':'Alarms (FM)',                   // @12/12 Add
   'field.optim':'Field Optimization',               // @12/12 Add
@@ -464,6 +465,8 @@ export const Enlanguage = {
   'BS.mobility': 'Mobility',
   'BS.ngRanHandoverSuccessRate': 'NG-RAN Handover Success Rate',
   'BS.energyConsumption': 'Energy Consumption',
+
+  'BS.dataItems':'Data Items',  // @2024/05/27 Add
   'BS.Power': 'Power ( kW )',
   'BS.percentage': 'Percentage ( % )',
   'BS.milliseconds': 'Milliseconds ( ms )',

--- a/src/app/shared/language-models/tw-language.ts
+++ b/src/app/shared/language-models/tw-language.ts
@@ -202,6 +202,7 @@ export const TwLanguage = {
   'field.performanceHistory':'歷史',         // @2024/05/27 Add
   'field.historyPerformanceSearch': '歷史效能查詢', // @2024/05/27 Add
   'field.performanceHistorySearch': '效能歷史查詢', // @2024/05/27 Add
+  'field.items':'項目',  // @2024/05/27 Add
 
   'field.reportFM':'告警資訊(FM)',          // @12/12 Add
   'field.optim':'場域優化',                  // @12/12 Add
@@ -476,7 +477,8 @@ export const TwLanguage = {
   'BS.hourlyInterval': '每小時區間',
 
   'BS.dataSource': '資料來源',
-  'BS.Power': '功耗 ( kW )',
+  'BS.dataItems':'資料項目',  // @2024/05/27 Add
+  'BS.Power': '功耗 ( kWh )',
   'BS.percentage': '百分比 ( % )',
   'BS.milliseconds': '毫秒 ( ms )',
   'BS.megabitsPerSecond': '兆位元每秒 ( Mbps )',


### PR DESCRIPTION
feat: 新增資料項目表格及對角線標題

- 在基站效能區的圖表下方新增資料項目表格
- 表格左上角標題「資料項目 / 每小時區間」設計為對角線排列
- 調整表格樣式，使其符合設計需求
- 當數據為 null 時，顯示 'languageService.i18n["BS.kpiValueNone"]'